### PR TITLE
Add SSH-style escape sequence support for terminating stuck sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ If no region is specified, you can select one through the interactive CLI.
 
 ### Commands
 
+#### Escape Sequence
+
+When in an interactive session (start, ssh, or scp), you can use the following escape sequence:
+
+- **Enter** followed by `~.` - Disconnect from the session (useful when network connection is stuck)
+
+This works the same way as the standard SSH escape sequence and provides a way to terminate sessions when network connectivity is lost. The tilde character (`~`) is only special when typed immediately after pressing Enter. Using `~` anywhere else (like `~/` for home directory or `~username`) works normally.
+
 #### `start`
 
 Start an interactive terminal session with an EC2 instance.

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -35,6 +35,9 @@ through AWS Systems Manager Session Manager.
 This command establishes an SCP connection through SSM, allowing secure file
 transfers without requiring direct SSH access to the instance.
 
+Escape Sequence:
+  Enter ~.   Disconnect from the session (useful when network is stuck)
+
 Example:
   gossm scp --exec "-i key.pem file.txt ec2-user@instance:/home/ec2-user/"
 `,

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -24,6 +24,9 @@ var (
 This command establishes a secure session with an EC2 instance without requiring SSH access or
 opening inbound ports. It uses the AWS SSM agent running on the target instance.
 
+Escape Sequence:
+  Enter ~.   Disconnect from the session (useful when network is stuck)
+
 Example:
   gossm start              # Interactive instance selection
   gossm start -t i-1234    # Connect to a specific instance ID

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -26,6 +26,9 @@ var (
 This command allows you to establish SSH connections without requiring inbound ports to be open
 or public IP addresses to be assigned to the instances.
 
+Escape Sequence:
+  Enter ~.   Disconnect from the session (useful when network is stuck)
+
 Examples:
   gossm ssh                               # Interactive instance and user selection
   gossm ssh -i ~/.ssh/mykey.pem           # Use a specific identity file (interactive instance selection)

--- a/internal/escape_simple.go
+++ b/internal/escape_simple.go
@@ -1,0 +1,232 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/fatih/color"
+	"golang.org/x/term"
+)
+
+// CallProcessWithSimpleEscape executes a process with simple escape sequence support
+// This version passes stdin directly to avoid echo issues
+func CallProcessWithSimpleEscape(process string, args ...string) error {
+	// Check if stdin is a terminal
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		// Not a terminal, fall back to direct process execution
+		return CallProcessDirect(process, args...)
+	}
+
+	// Create command with direct stdin/stdout/stderr
+	cmd := exec.Command(process, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	
+	// Create a pipe for stdin so we can monitor it
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return WrapError(err)
+	}
+
+	// Start the process
+	if err := cmd.Start(); err != nil {
+		return WrapError(err)
+	}
+
+	// Set terminal to raw mode to capture escape sequences
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		// If we can't set raw mode, just pass through directly
+		cmd.Stdin = os.Stdin
+		return cmd.Wait()
+	}
+	
+	// Ensure we restore terminal state on exit
+	defer func() {
+		term.Restore(int(os.Stdin.Fd()), oldState)
+	}()
+	
+	// Add a small delay then print newline to fix prompt alignment
+	// The SSM plugin prints "Starting session..." without a newline
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		fmt.Fprintf(os.Stderr, "\r\n")
+	}()
+
+	// Set up contexts and channels
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle stdin copying with escape detection
+	stdinErr := make(chan error, 1)
+	escapeDetected := make(chan bool, 1)
+	
+	go func() {
+		stdinErr <- copyWithEscapeDetection(ctx, stdinPipe, os.Stdin, escapeDetected)
+	}()
+
+	// Set up signal handling
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigs)
+
+	// Wait for process completion, escape sequence, or signal
+	processDone := make(chan error, 1)
+	go func() {
+		processDone <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-processDone:
+		// Process exited normally
+		cancel()
+		// Add newline before the "Exiting session" message for proper alignment
+		fmt.Fprintf(os.Stderr, "\r\n")
+		return err
+		
+	case <-escapeDetected:
+		// Escape sequence detected
+		cancel()
+		stdinPipe.Close()
+		
+		// Restore terminal before printing
+		term.Restore(int(os.Stdin.Fd()), oldState)
+		
+		fmt.Fprintf(os.Stderr, "\r\n%s\r\n", 
+			color.YellowString("Escape sequence detected. Terminating session..."))
+		
+		// Terminate the process gracefully
+		return terminateGracefully(cmd)
+		
+	case sig := <-sigs:
+		// Signal received
+		cancel()
+		stdinPipe.Close()
+		cmd.Process.Signal(sig)
+		<-processDone
+		return nil
+		
+	case err := <-stdinErr:
+		// Stdin copy error (likely process died)
+		cancel()
+		<-processDone
+		return err
+	}
+}
+
+// copyWithEscapeDetection copies stdin to the process while detecting escape sequences
+func copyWithEscapeDetection(ctx context.Context, dst io.WriteCloser, src io.Reader, escapeDetected chan<- bool) error {
+	defer dst.Close()
+	
+	lastWasNewline := true
+	tildeSeen := false
+	buf := make([]byte, 1)
+	
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			n, err := src.Read(buf)
+			if err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+			
+			if n == 0 {
+				continue
+			}
+			
+			b := buf[0]
+			
+			// Check for escape sequence only at start of line
+			if lastWasNewline && b == '~' {
+				tildeSeen = true
+				lastWasNewline = false
+				continue // Don't send the tilde yet
+			} else if tildeSeen {
+				if b == '.' {
+					// Escape sequence complete
+					escapeDetected <- true
+					return nil
+				} else {
+					// Not an escape sequence, send the tilde and current char
+					// This handles ~/, ~user, ~~, and any other ~ usage
+					dst.Write([]byte{'~', b})
+				}
+				tildeSeen = false
+				if b == '\r' || b == '\n' {
+					lastWasNewline = true
+				} else {
+					lastWasNewline = false
+				}
+			} else {
+				// Normal character
+				dst.Write([]byte{b})
+				if b == '\r' || b == '\n' {
+					lastWasNewline = true
+				} else {
+					lastWasNewline = false
+				}
+			}
+		}
+	}
+}
+
+// terminateGracefully attempts to terminate a process gracefully
+func terminateGracefully(cmd *exec.Cmd) error {
+	// Send SIGTERM first
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		// Process may have already exited
+		return nil
+	}
+	
+	// Wait for graceful termination with timeout
+	done := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		done <- err
+	}()
+	
+	select {
+	case err := <-done:
+		// Process exited gracefully
+		if err != nil && 
+		   err.Error() != "signal: terminated" && 
+		   err.Error() != "signal: broken pipe" &&
+		   !isWaitError(err) {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "%s\r\n", 
+			color.GreenString("Session terminated gracefully"))
+		return nil
+	case <-time.After(3 * time.Second):
+		// Timeout reached, force kill
+		fmt.Fprintf(os.Stderr, "%s\r\n", 
+			color.YellowString("Graceful termination timed out, forcing exit..."))
+		if err := cmd.Process.Kill(); err != nil {
+			// Process may have already exited
+			return nil
+		}
+		<-done // Wait for process to actually exit
+		return nil
+	}
+}
+
+// isWaitError checks if the error is a wait-related error that we can ignore
+func isWaitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return errStr == "wait: no child processes" || 
+	       errStr == "waitid: no child processes"
+}

--- a/internal/ssm.go
+++ b/internal/ssm.go
@@ -635,8 +635,14 @@ func PrintReady(cmd, region, target string) {
 		color.YellowString(target))
 }
 
-// CallProcess executes an external process with the given arguments
+// CallProcess executes an external process with escape sequence support for interactive sessions
 func CallProcess(process string, args ...string) error {
+	// Use simple escape sequence handler for interactive sessions
+	return CallProcessWithSimpleEscape(process, args...)
+}
+
+// CallProcessDirect executes an external process without escape sequence handling
+func CallProcessDirect(process string, args ...string) error {
 	// Create command
 	cmd := exec.Command(process, args...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary
Implements SSH-style escape sequence (`~.`) to disconnect from SSM sessions when network connectivity is lost. This provides a way to cleanly exit sessions that become unresponsive due to network issues.

## Problem
When network connectivity is lost during an SSM session, there's no way to cleanly exit the session. Unlike SSH which supports the `~.` escape sequence, gossm sessions become stuck and require killing the terminal or process.

## Solution
Added escape sequence detection that monitors for `Enter` followed by `~.` to disconnect the session, matching standard SSH behavior.

## Implementation Details
- Uses terminal raw mode to intercept keystrokes while maintaining proper terminal behavior
- Graceful termination with 3-second timeout before force kill
- Only active in interactive terminal sessions (non-TTY sessions bypass escape handling)
- Tilde (`~`) is only special at the start of a line, preserving normal usage like `~/` for home directory
- Works for all interactive commands: `start`, `ssh`, and `scp`

## Testing
Tested on:
- **macOS Sequoia 15.6.1** (Apple Silicon) - SSM interactive sessions
- **Debian Linux ARM64** - SSM interactive sessions

Test scenarios verified:
- Normal session with escape sequence termination
- Network disconnection with escape sequence recovery
- Normal tilde usage (`~/`, `~username`) works as expected
- Non-terminal/piped input bypasses escape handling

## Changes
- Added `internal/escape_simple.go` - Core escape sequence handler
- Modified `internal/ssm.go` - Updated `CallProcess` to use escape handler
- Updated help text in `cmd/session.go`, `cmd/ssh.go`, `cmd/scp.go`
- Updated `README.md` with escape sequence documentation