### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,21 @@
+name: PR Title
+
+# PRs are squash-merged, so the PR title becomes the commit message on
+# master and must follow Conventional Commits (see CONTRIBUTING.md).
+# No code is checked out here, so pull_request_target is safe.
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Pull requests
+
+Pull requests are **squash-merged**: your PR title becomes the commit
+message on `master`, so it must follow
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <description>
+```
+
+Examples:
+
+- `feat: add region flag to the fwd command`
+- `fix(ssh): quote identity file paths with spaces`
+- `docs: describe container usage`
+
+A CI check validates the title; the standard types are accepted
+(`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`,
+`ci`, `chore`, `revert`). Individual commits inside a PR can be
+whatever you like — only the title matters.
+
+Release notes are generated from these commit messages: `feat` lands
+under Features, `fix` under Bug fixes, `chore(deps)` under
+Dependencies; `docs`/`test`/`ci`/`style` are excluded.
+
+## Development
+
+```sh
+make build     # build the binary
+make test      # tests with race detector and coverage
+make lint      # golangci-lint
+make vet       # go vet
+make snapshot  # local release build without publishing (needs goreleaser)
+```
+
+CI runs lint, tests, and cross-compilation for every PR; `master` only
+changes through PRs with passing checks.
+
+## Releasing (maintainers)
+
+Run the **Release** workflow from the Actions tab with a `vX.Y.Z`
+version (it tags `master` and publishes via GoReleaser), or push a
+`vX.Y.Z` tag by hand. Tags always carry the `v` prefix.


### PR DESCRIPTION
Closes #12.

## Merge strategy decision

The repo is now configured for **squash-merge only** (already applied via the API): the PR title becomes the commit message on master, with the PR body as the commit body. One check on the title therefore enforces Conventional Commits for everything that lands on master.

## What this adds

- **PR Title workflow**: `amannn/action-semantic-pull-request` (SHA-pinned, v6.1.1) validates the PR title against Conventional Commits. It runs on `pull_request_target` with no code checkout, so it is safe and works for fork PRs. Standard types accepted (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`).
- **CONTRIBUTING.md**: documents the PR-title convention with examples, which types land where in release notes, the local `make` targets, and the release process.

## After merging

The `Validate PR title` check should be added to the `protect-master` ruleset's required status checks. It can't be required before this merges — `pull_request_target` runs the workflow from master, so the check first appears on PRs opened after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
