### PR TITLE
ci: require the PR title check on master

### DIFF
--- a/.github/ruleset-protect-master.json
+++ b/.github/ruleset-protect-master.json
@@ -26,6 +26,7 @@
       "parameters": {
         "strict_required_status_checks_policy": false,
         "required_status_checks": [
+          { "context": "Validate PR title" },
           { "context": "Lint" },
           { "context": "Test" },
           { "context": "Build (linux/amd64)" },


### PR DESCRIPTION
Syncs `.github/ruleset-protect-master.json` with the applied ruleset: `Validate PR title` is now a required status check (added via API after #18 merged, since `pull_request_target` checks only run for PRs opened once the workflow exists on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)