### PR TITLE
fix: use the correct AWS_SHARED_CREDENTIALS_FILE env var name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,9 +166,9 @@ func setupAWSCredentials(awsProfile, awsRegion string) {
 	}
 
 	// Check for special MFA credentials file
-	if _, err := os.Stat(credentialWithMFA); err == nil && os.Getenv("AWS_SHAREDcredentialS_FILE") == "" {
+	if _, err := os.Stat(credentialWithMFA); err == nil && os.Getenv("AWS_SHARED_CREDENTIALS_FILE") == "" {
 		color.Yellow("[Use] gossm default mfa credential file %s", credentialWithMFA)
-		_ = os.Setenv("AWS_SHAREDcredentialS_FILE", credentialWithMFA)
+		_ = os.Setenv("AWS_SHARED_CREDENTIALS_FILE", credentialWithMFA)
 	}
 
 	// Use AWS SDK's built-in credential chain with our profile


### PR DESCRIPTION
Closes nothing tracked — spotted during the #7 lint work. `cmd/root.go` read and set the misspelled `AWS_SHAREDcredentialS_FILE`, so the automatic MFA credentials-file pickup never reached the AWS SDK (which reads `AWS_SHARED_CREDENTIALS_FILE`), and a user's correctly-exported value wasn't seen by the guard. `cmd/mfa.go` already documented the correct name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)