### PR TITLE
test: add offline unit tests and a coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
           go-version-file: go.mod
       - run: go vet ./...
       - run: go test ./... --count 1 -race -covermode=atomic -coverprofile=coverage.txt
+      # Coverage floor: a ratchet, not a target. Raise it as coverage grows.
+      - name: Enforce coverage floor
+        run: |
+          total=$(go tool cover -func=coverage.txt | awk '/^total:/ {sub(/%/,"",$NF); print $NF}')
+          echo "total coverage: ${total}%"
+          awk -v t="$total" 'BEGIN { exit (t+0 < 25) ? 1 : 0 }' || { echo "::error::coverage ${total}% is below the 25% floor"; exit 1; }
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/cmd/fwd_test.go
+++ b/cmd/fwd_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/cmd/fwdrem_test.go
+++ b/cmd/fwdrem_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/cmd/mfa_test.go
+++ b/cmd/mfa_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,1 +1,35 @@
 package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestGetAWSProfile(t *testing.T) {
+	t.Cleanup(func() { viper.Set("profile", "") })
+
+	t.Run("default when nothing is set", func(t *testing.T) {
+		viper.Set("profile", "")
+		t.Setenv("AWS_PROFILE", "")
+		if got := getAWSProfile(); got != defaultProfile {
+			t.Errorf("getAWSProfile() = %q, want %q", got, defaultProfile)
+		}
+	})
+
+	t.Run("environment variable", func(t *testing.T) {
+		viper.Set("profile", "")
+		t.Setenv("AWS_PROFILE", "from-env")
+		if got := getAWSProfile(); got != "from-env" {
+			t.Errorf("getAWSProfile() = %q, want %q", got, "from-env")
+		}
+	})
+
+	t.Run("flag beats environment", func(t *testing.T) {
+		viper.Set("profile", "from-flag")
+		t.Setenv("AWS_PROFILE", "from-env")
+		if got := getAWSProfile(); got != "from-flag" {
+			t.Errorf("getAWSProfile() = %q, want %q", got, "from-flag")
+		}
+	})
+}

--- a/cmd/scp_test.go
+++ b/cmd/scp_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/internal/assets_test.go
+++ b/internal/assets_test.go
@@ -1,0 +1,241 @@
+package internal
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetSsmPluginName(t *testing.T) {
+	name := GetSsmPluginName()
+	if runtime.GOOS == "windows" {
+		if name != "session-manager-plugin.exe" {
+			t.Errorf("plugin name = %q", name)
+		}
+	} else if name != "session-manager-plugin" {
+		t.Errorf("plugin name = %q", name)
+	}
+}
+
+func TestGetPluginDirectory(t *testing.T) {
+	dir := GetPluginDirectory()
+	if !strings.Contains(dir, filepath.Join(".gossm", "plugins")) {
+		t.Errorf("plugin directory %q does not end in .gossm/plugins", dir)
+	}
+}
+
+func TestCalculateHash(t *testing.T) {
+	hash, err := calculateHash([]byte("hello"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	const want = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if hash != want {
+		t.Errorf("hash = %q, want %q", hash, want)
+	}
+}
+
+func TestPluginInfoRoundtrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugin-info.json")
+
+	saved := PluginInfo{
+		Version:     "1.2.3",
+		InstallDate: time.Now().UTC().Truncate(time.Second),
+		Source:      "downloaded",
+		Hash:        "abc123",
+	}
+	if err := savePluginInfo(path, saved); err != nil {
+		t.Fatalf("savePluginInfo: %v", err)
+	}
+
+	loaded, err := loadPluginInfo(path)
+	if err != nil {
+		t.Fatalf("loadPluginInfo: %v", err)
+	}
+	if loaded.Version != saved.Version || loaded.Source != saved.Source || loaded.Hash != saved.Hash {
+		t.Errorf("loaded = %+v, want %+v", loaded, saved)
+	}
+}
+
+func TestLoadPluginInfoErrors(t *testing.T) {
+	if _, err := loadPluginInfo(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Error("expected error for missing file")
+	}
+
+	corrupt := filepath.Join(t.TempDir(), "corrupt.json")
+	if err := os.WriteFile(corrupt, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadPluginInfo(corrupt); err == nil {
+		t.Error("expected error for corrupt file")
+	}
+}
+
+func TestValidatePlugin(t *testing.T) {
+	if err := ValidatePlugin(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Error("expected error for missing plugin")
+	}
+
+	if runtime.GOOS != "windows" {
+		path := filepath.Join(t.TempDir(), "plugin")
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ValidatePlugin(path); err != nil {
+			t.Fatalf("ValidatePlugin on non-executable file: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&0111 == 0 {
+			t.Error("ValidatePlugin did not make the plugin executable")
+		}
+	}
+}
+
+func TestExtractBinary(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "downloaded")
+	content := []byte("binary-bytes")
+	if err := os.WriteFile(src, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	destDir := t.TempDir()
+	destPath, err := extractBinary(src, destDir)
+	if err != nil {
+		t.Fatalf("extractBinary: %v", err)
+	}
+	if filepath.Base(destPath) != GetSsmPluginName() {
+		t.Errorf("dest name = %q", filepath.Base(destPath))
+	}
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("extracted content = %q, want %q", got, content)
+	}
+}
+
+// buildZip writes a zip archive with the given name→content entries.
+func buildZip(t *testing.T, path string, entries map[string][]byte) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for name, content := range entries {
+		f, err := w.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtractFromZipFlat(t *testing.T) {
+	zipPath := filepath.Join(t.TempDir(), "plugin.zip")
+	content := []byte("windows-plugin")
+	buildZip(t, zipPath, map[string][]byte{"session-manager-plugin.exe": content})
+
+	destDir := t.TempDir()
+	destPath, err := extractFromZip(zipPath, destDir)
+	if err != nil {
+		t.Fatalf("extractFromZip: %v", err)
+	}
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("extracted content = %q, want %q", got, content)
+	}
+}
+
+func TestExtractFromZipNested(t *testing.T) {
+	// AWS ships the Windows plugin as a zip that contains package.zip.
+	inner := filepath.Join(t.TempDir(), "package.zip")
+	content := []byte("nested-plugin")
+	buildZip(t, inner, map[string][]byte{"bin/session-manager-plugin.exe": content})
+	innerBytes, err := os.ReadFile(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outer := filepath.Join(t.TempDir(), "SessionManagerPlugin.zip")
+	buildZip(t, outer, map[string][]byte{"package.zip": innerBytes})
+
+	destPath, err := extractFromZip(outer, t.TempDir())
+	if err != nil {
+		t.Fatalf("extractFromZip: %v", err)
+	}
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("extracted content = %q, want %q", got, content)
+	}
+}
+
+func TestExtractFromZipMissingBinary(t *testing.T) {
+	zipPath := filepath.Join(t.TempDir(), "empty.zip")
+	buildZip(t, zipPath, map[string][]byte{"readme.txt": []byte("hi")})
+
+	if _, err := extractFromZip(zipPath, t.TempDir()); err == nil {
+		t.Error("expected error when the zip has no plugin binary")
+	}
+}
+
+func TestGetDownloadInfoForPlatform(t *testing.T) {
+	url, extract, err := getDownloadInfoForPlatform("1.2.3.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if extract == nil {
+		t.Error("extract function is nil")
+	}
+	if !strings.Contains(url, "1.2.3.0") {
+		t.Errorf("url %q does not contain the version", url)
+	}
+	if !strings.HasPrefix(url, "https://s3.amazonaws.com/session-manager-downloads/plugin/") {
+		t.Errorf("url %q has unexpected prefix", url)
+	}
+}
+
+func TestGetEmbeddedPlugin(t *testing.T) {
+	dir := t.TempDir()
+
+	data, err := getEmbeddedPlugin(dir)
+	if err != nil {
+		t.Fatalf("getEmbeddedPlugin: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("embedded plugin is empty")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, GetSsmPluginName())); err != nil {
+		t.Errorf("plugin file not written: %v", err)
+	}
+
+	info, err := loadPluginInfo(filepath.Join(dir, pluginInfoFile))
+	if err != nil {
+		t.Fatalf("plugin info not written: %v", err)
+	}
+	if info.Source != "embedded" || info.Version != "embedded" {
+		t.Errorf("plugin info = %+v", info)
+	}
+}

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestWrapErrorNil(t *testing.T) {
+	if err := WrapError(nil); err != nil {
+		t.Fatalf("WrapError(nil) = %v, want nil", err)
+	}
+}
+
+func TestWrapError(t *testing.T) {
+	base := errors.New("boom")
+	err := WrapError(base)
+	if err == nil {
+		t.Fatal("WrapError returned nil for a non-nil error")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("wrapped error %q does not contain the original message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "TestWrapError") {
+		t.Errorf("wrapped error %q does not contain the caller function name", err.Error())
+	}
+}

--- a/internal/escape_simple_test.go
+++ b/internal/escape_simple_test.go
@@ -1,0 +1,117 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeRecorder is an io.WriteCloser that records everything written to it.
+type writeRecorder struct {
+	bytes.Buffer
+	closed bool
+}
+
+func (w *writeRecorder) Close() error {
+	w.closed = true
+	return nil
+}
+
+func runEscapeCopy(t *testing.T, input string) (output string, escaped bool) {
+	t.Helper()
+
+	dst := &writeRecorder{}
+	escapeDetected := make(chan bool, 1)
+
+	err := copyWithEscapeDetection(context.Background(), dst, strings.NewReader(input), escapeDetected)
+	if err != nil {
+		t.Fatalf("copyWithEscapeDetection(%q) returned error: %v", input, err)
+	}
+	if !dst.closed {
+		t.Errorf("copyWithEscapeDetection(%q) did not close the destination", input)
+	}
+
+	select {
+	case <-escapeDetected:
+		escaped = true
+	default:
+	}
+
+	return dst.String(), escaped
+}
+
+func TestCopyWithEscapeDetection(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantOutput  string
+		wantEscaped bool
+	}{
+		{"plain text", "hello", "hello", false},
+		{"escape at start", "~.", "", true},
+		{"escape after newline", "line\n~.", "line\n", true},
+		{"double tilde is literal", "~~ok", "~~ok", false},
+		{"tilde plus other char", "~x", "~x", false},
+		{"mid-line tilde dot is literal", "a~.", "a~.", false},
+		{"carriage return counts as newline", "a\r~.", "a\r", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, escaped := runEscapeCopy(t, tt.input)
+			if output != tt.wantOutput {
+				t.Errorf("output = %q, want %q", output, tt.wantOutput)
+			}
+			if escaped != tt.wantEscaped {
+				t.Errorf("escaped = %v, want %v", escaped, tt.wantEscaped)
+			}
+		})
+	}
+}
+
+func TestIsWaitError(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("wait: no child processes"), true},
+		{errors.New("waitid: no child processes"), true},
+		{errors.New("some other error"), false},
+	}
+
+	for _, tt := range tests {
+		if got := isWaitError(tt.err); got != tt.want {
+			t.Errorf("isWaitError(%v) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestTerminateGracefully(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX signals")
+	}
+
+	cmd := exec.Command("sleep", "10")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start test process: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- terminateGracefully(cmd) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("terminateGracefully returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("terminateGracefully did not return in time")
+	}
+}

--- a/internal/ssm.go
+++ b/internal/ssm.go
@@ -32,10 +32,11 @@ const (
 
 	// commandTimeout is the timeout for SSM commands in seconds
 	commandTimeout = 60
-
-	// pollInterval is the interval for checking command status
-	pollInterval = 1 * time.Second
 )
+
+// pollInterval is the interval for checking command status.
+// It is a variable so tests can shorten it.
+var pollInterval = 1 * time.Second
 
 // AWS region list - kept for fallback if API fails
 var defaultAwsRegions = []string{
@@ -72,6 +73,18 @@ type Port struct {
 	Local  string // Local port
 }
 
+// ec2API is the subset of the EC2 client used by gossm; *ec2.Client implements it.
+type ec2API interface {
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	DescribeRegions(ctx context.Context, params *ec2.DescribeRegionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRegionsOutput, error)
+}
+
+// ssmAPI is the subset of the SSM client used by gossm; *ssm.Client implements it.
+type ssmAPI interface {
+	DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error)
+	GetCommandInvocation(ctx context.Context, params *ssm.GetCommandInvocationInput, optFns ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error)
+}
+
 // AskUser prompts the user to select an SSH username
 func AskUser() (*User, error) {
 	prompt := &survey.Input{
@@ -91,7 +104,7 @@ func AskUser() (*User, error) {
 // AskRegion prompts the user to select an AWS region
 func AskRegion(ctx context.Context, cfg aws.Config) (*Region, error) {
 	// Get regions from AWS API
-	regions, err := getAvailableRegions(ctx, cfg)
+	regions, err := getAvailableRegions(ctx, ec2.NewFromConfig(cfg))
 	if err != nil {
 		// Fall back to default regions if API call fails
 		regions = make([]string, len(defaultAwsRegions))
@@ -121,9 +134,7 @@ func AskRegion(ctx context.Context, cfg aws.Config) (*Region, error) {
 }
 
 // getAvailableRegions fetches available AWS regions
-func getAvailableRegions(ctx context.Context, cfg aws.Config) ([]string, error) {
-	client := ec2.NewFromConfig(cfg)
-
+func getAvailableRegions(ctx context.Context, client ec2API) ([]string, error) {
 	output, err := client.DescribeRegions(ctx, &ec2.DescribeRegionsInput{
 		AllRegions: aws.Bool(true),
 	})
@@ -261,11 +272,14 @@ func AskPorts() (*Port, error) {
 
 // FindInstances returns all running EC2 instances that have SSM agent
 func FindInstances(ctx context.Context, cfg aws.Config) (map[string]*Target, error) {
-	client := ec2.NewFromConfig(cfg)
+	return findInstances(ctx, ec2.NewFromConfig(cfg), ssm.NewFromConfig(cfg))
+}
+
+func findInstances(ctx context.Context, client ec2API, ssmClient ssmAPI) (map[string]*Target, error) {
 	table := make(map[string]*Target)
 
 	// Find instance IDs with connected SSM agent
-	instanceIDs, err := FindInstanceIdsWithConnectedSSM(ctx, cfg)
+	instanceIDs, err := findInstanceIdsWithConnectedSSM(ctx, ssmClient)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +334,10 @@ func FindInstances(ctx context.Context, cfg aws.Config) (map[string]*Target, err
 
 // FindInstanceIdsWithConnectedSSM returns instance IDs that have SSM agent connected
 func FindInstanceIdsWithConnectedSSM(ctx context.Context, cfg aws.Config) ([]string, error) {
-	client := ssm.NewFromConfig(cfg)
+	return findInstanceIdsWithConnectedSSM(ctx, ssm.NewFromConfig(cfg))
+}
+
+func findInstanceIdsWithConnectedSSM(ctx context.Context, client ssmAPI) ([]string, error) {
 	var instanceIDs []string
 
 	// Initial query for instances with SSM
@@ -363,8 +380,10 @@ func FindInstanceIdsWithConnectedSSM(ctx context.Context, cfg aws.Config) ([]str
 
 // FindInstanceIdByIp finds an EC2 instance ID by IP address
 func FindInstanceIdByIp(ctx context.Context, cfg aws.Config, ip string) (string, error) {
-	client := ec2.NewFromConfig(cfg)
+	return findInstanceIdByIp(ctx, ec2.NewFromConfig(cfg), ip)
+}
 
+func findInstanceIdByIp(ctx context.Context, client ec2API, ip string) (string, error) {
 	// Function to find an instance with matching IP
 	findInstanceWithIP := func(output *ec2.DescribeInstancesOutput) string {
 		for _, reservation := range output.Reservations {
@@ -428,8 +447,10 @@ func FindInstanceIdByIp(ctx context.Context, cfg aws.Config, ip string) (string,
 
 // FindDomainByInstanceId finds DNS names for an EC2 instance by ID
 func FindDomainByInstanceId(ctx context.Context, cfg aws.Config, instanceID string) ([]string, error) {
-	client := ec2.NewFromConfig(cfg)
+	return findDomainByInstanceId(ctx, ec2.NewFromConfig(cfg), instanceID)
+}
 
+func findDomainByInstanceId(ctx context.Context, client ec2API, instanceID string) ([]string, error) {
 	// Function to find domain names for an instance
 	findDomainForInstance := func(output *ec2.DescribeInstancesOutput, id string) []string {
 		for _, reservation := range output.Reservations {
@@ -531,15 +552,19 @@ func DeleteStartSession(ctx context.Context, cfg aws.Config, input *ssm.Terminat
 // SendCommand sends a command to EC2 instances via SSM
 func SendCommand(ctx context.Context, cfg aws.Config, targets []*Target, command string) (*ssm.SendCommandOutput, error) {
 	client := ssm.NewFromConfig(cfg)
+	return client.SendCommand(ctx, buildSendCommandInput(targets, command))
+}
 
+// buildSendCommandInput constructs the SSM SendCommand request for running a
+// shell command on the given targets.
+func buildSendCommandInput(targets []*Target, command string) *ssm.SendCommandInput {
 	// Extract instance IDs from targets
 	instanceIDs := make([]string, 0, len(targets))
 	for _, target := range targets {
 		instanceIDs = append(instanceIDs, target.Name)
 	}
 
-	// Create command input
-	input := &ssm.SendCommandInput{
+	return &ssm.SendCommandInput{
 		DocumentName:   aws.String(shellDocumentName),
 		InstanceIds:    instanceIDs,
 		TimeoutSeconds: aws.Int32(commandTimeout),
@@ -550,8 +575,6 @@ func SendCommand(ctx context.Context, cfg aws.Config, targets []*Target, command
 			"commands": {command},
 		},
 	}
-
-	return client.SendCommand(ctx, input)
 }
 
 // PrintCommandInvocation watches and displays command invocation results
@@ -569,7 +592,7 @@ func PrintCommandInvocation(ctx context.Context, cfg aws.Config, inputs []*ssm.G
 }
 
 // monitorCommandInvocation monitors a single command invocation
-func monitorCommandInvocation(ctx context.Context, client *ssm.Client, input *ssm.GetCommandInvocationInput, wg *sync.WaitGroup) {
+func monitorCommandInvocation(ctx context.Context, client ssmAPI, input *ssm.GetCommandInvocationInput, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	ticker := time.NewTicker(pollInterval)

--- a/internal/ssm_test.go
+++ b/internal/ssm_test.go
@@ -1,0 +1,369 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// fakeEC2 implements ec2API with configurable responses.
+type fakeEC2 struct {
+	describeInstances func(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
+	describeRegions   func(*ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error)
+}
+
+func (f *fakeEC2) DescribeInstances(_ context.Context, in *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return f.describeInstances(in)
+}
+
+func (f *fakeEC2) DescribeRegions(_ context.Context, in *ec2.DescribeRegionsInput, _ ...func(*ec2.Options)) (*ec2.DescribeRegionsOutput, error) {
+	return f.describeRegions(in)
+}
+
+// fakeSSM implements ssmAPI with configurable responses.
+type fakeSSM struct {
+	describeInstanceInformation func(*ssm.DescribeInstanceInformationInput) (*ssm.DescribeInstanceInformationOutput, error)
+	getCommandInvocation        func(*ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error)
+}
+
+func (f *fakeSSM) DescribeInstanceInformation(_ context.Context, in *ssm.DescribeInstanceInformationInput, _ ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error) {
+	return f.describeInstanceInformation(in)
+}
+
+func (f *fakeSSM) GetCommandInvocation(_ context.Context, in *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+	return f.getCommandInvocation(in)
+}
+
+func instanceInfo(ids ...string) []ssmtypes.InstanceInformation {
+	infos := make([]ssmtypes.InstanceInformation, 0, len(ids))
+	for _, id := range ids {
+		infos = append(infos, ssmtypes.InstanceInformation{InstanceId: aws.String(id)})
+	}
+	return infos
+}
+
+func TestFindInstanceIdsWithConnectedSSMPagination(t *testing.T) {
+	f := &fakeSSM{describeInstanceInformation: func(in *ssm.DescribeInstanceInformationInput) (*ssm.DescribeInstanceInformationOutput, error) {
+		if in.NextToken == nil {
+			return &ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: instanceInfo("i-1", "i-2"),
+				NextToken:               aws.String("page2"),
+			}, nil
+		}
+		if *in.NextToken != "page2" {
+			t.Errorf("unexpected NextToken %q", *in.NextToken)
+		}
+		return &ssm.DescribeInstanceInformationOutput{
+			InstanceInformationList: instanceInfo("i-3"),
+		}, nil
+	}}
+
+	ids, err := findInstanceIdsWithConnectedSSM(context.Background(), f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"i-1", "i-2", "i-3"}
+	if fmt.Sprint(ids) != fmt.Sprint(want) {
+		t.Errorf("ids = %v, want %v", ids, want)
+	}
+}
+
+func TestFindInstanceIdsWithConnectedSSMError(t *testing.T) {
+	f := &fakeSSM{describeInstanceInformation: func(*ssm.DescribeInstanceInformationInput) (*ssm.DescribeInstanceInformationOutput, error) {
+		return nil, errors.New("api down")
+	}}
+
+	if _, err := findInstanceIdsWithConnectedSSM(context.Background(), f); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestFindInstances(t *testing.T) {
+	ssmFake := &fakeSSM{describeInstanceInformation: func(*ssm.DescribeInstanceInformationInput) (*ssm.DescribeInstanceInformationOutput, error) {
+		return &ssm.DescribeInstanceInformationOutput{InstanceInformationList: instanceInfo("i-1", "i-2")}, nil
+	}}
+
+	ec2Fake := &fakeEC2{describeInstances: func(in *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+		return &ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{{
+				Instances: []ec2types.Instance{
+					{
+						InstanceId:     aws.String("i-1"),
+						PublicDnsName:  aws.String("pub.example.com"),
+						PrivateDnsName: aws.String("priv.example.com"),
+						Tags:           []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("web")}},
+					},
+					{
+						InstanceId: aws.String("i-2"),
+					},
+				},
+			}},
+		}, nil
+	}}
+
+	table, err := findInstances(context.Background(), ec2Fake, ssmFake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	web, ok := table["web\t(i-1)"]
+	if !ok {
+		t.Fatalf("expected key %q in table, got keys %v", "web\t(i-1)", keys(table))
+	}
+	if web.Name != "i-1" || web.PublicDomain != "pub.example.com" || web.PrivateDomain != "priv.example.com" {
+		t.Errorf("unexpected target %+v", web)
+	}
+
+	if _, ok := table["\t(i-2)"]; !ok {
+		t.Errorf("expected nameless instance key %q, got keys %v", "\t(i-2)", keys(table))
+	}
+}
+
+func TestFindInstancesBatching(t *testing.T) {
+	// 250 connected instances must be described in batches of at most 199.
+	manyIDs := make([]string, 250)
+	for i := range manyIDs {
+		manyIDs[i] = fmt.Sprintf("i-%03d", i)
+	}
+
+	ssmFake := &fakeSSM{describeInstanceInformation: func(*ssm.DescribeInstanceInformationInput) (*ssm.DescribeInstanceInformationOutput, error) {
+		return &ssm.DescribeInstanceInformationOutput{InstanceInformationList: instanceInfo(manyIDs...)}, nil
+	}}
+
+	var batchSizes []int
+	ec2Fake := &fakeEC2{describeInstances: func(in *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+		for _, f := range in.Filters {
+			if aws.ToString(f.Name) == "instance-id" {
+				batchSizes = append(batchSizes, len(f.Values))
+			}
+		}
+		return &ec2.DescribeInstancesOutput{}, nil
+	}}
+
+	if _, err := findInstances(context.Background(), ec2Fake, ssmFake); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fmt.Sprint(batchSizes) != fmt.Sprint([]int{199, 51}) {
+		t.Errorf("batch sizes = %v, want [199 51]", batchSizes)
+	}
+}
+
+func TestFindInstanceIdByIp(t *testing.T) {
+	pageOne := &ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{{
+			Instances: []ec2types.Instance{{
+				InstanceId:      aws.String("i-pub"),
+				PublicIpAddress: aws.String("1.2.3.4"),
+			}},
+		}},
+		NextToken: aws.String("page2"),
+	}
+	pageTwo := &ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{{
+			Instances: []ec2types.Instance{{
+				InstanceId:       aws.String("i-priv"),
+				PrivateIpAddress: aws.String("10.0.0.5"),
+			}},
+		}},
+	}
+
+	f := &fakeEC2{describeInstances: func(in *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+		if in.NextToken == nil {
+			return pageOne, nil
+		}
+		return pageTwo, nil
+	}}
+
+	tests := []struct {
+		ip      string
+		want    string
+		wantErr bool
+	}{
+		{"1.2.3.4", "i-pub", false},
+		{"10.0.0.5", "i-priv", false},
+		{"192.168.0.9", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := findInstanceIdByIp(context.Background(), f, tt.ip)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("findInstanceIdByIp(%q): expected error, got %q", tt.ip, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("findInstanceIdByIp(%q): unexpected error: %v", tt.ip, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("findInstanceIdByIp(%q) = %q, want %q", tt.ip, got, tt.want)
+		}
+	}
+}
+
+func TestFindDomainByInstanceId(t *testing.T) {
+	f := &fakeEC2{describeInstances: func(in *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+		return &ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{{
+				Instances: []ec2types.Instance{{
+					InstanceId:     aws.String("i-1"),
+					PublicDnsName:  aws.String("pub.example.com"),
+					PrivateDnsName: aws.String("priv.example.com"),
+				}},
+			}},
+		}, nil
+	}}
+
+	domains, err := findDomainByInstanceId(context.Background(), f, "i-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprint(domains) != fmt.Sprint([]string{"pub.example.com", "priv.example.com"}) {
+		t.Errorf("domains = %v", domains)
+	}
+
+	if _, err := findDomainByInstanceId(context.Background(), f, "i-missing"); err == nil {
+		t.Error("expected error for unknown instance id")
+	}
+}
+
+func TestGetAvailableRegions(t *testing.T) {
+	f := &fakeEC2{describeRegions: func(*ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
+		return &ec2.DescribeRegionsOutput{Regions: []ec2types.Region{
+			{RegionName: aws.String("eu-north-1")},
+			{RegionName: nil},
+			{RegionName: aws.String("us-east-1")},
+		}}, nil
+	}}
+
+	regions, err := getAvailableRegions(context.Background(), f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprint(regions) != fmt.Sprint([]string{"eu-north-1", "us-east-1"}) {
+		t.Errorf("regions = %v", regions)
+	}
+}
+
+func TestBuildSendCommandInput(t *testing.T) {
+	targets := []*Target{{Name: "i-1"}, {Name: "i-2"}}
+	input := buildSendCommandInput(targets, "uptime")
+
+	if aws.ToString(input.DocumentName) != shellDocumentName {
+		t.Errorf("DocumentName = %q", aws.ToString(input.DocumentName))
+	}
+	if fmt.Sprint(input.InstanceIds) != fmt.Sprint([]string{"i-1", "i-2"}) {
+		t.Errorf("InstanceIds = %v", input.InstanceIds)
+	}
+	if cmds := input.Parameters["commands"]; len(cmds) != 1 || cmds[0] != "uptime" {
+		t.Errorf("Parameters[commands] = %v", input.Parameters["commands"])
+	}
+	if !input.CloudWatchOutputConfig.CloudWatchOutputEnabled {
+		t.Error("CloudWatchOutputEnabled = false, want true")
+	}
+}
+
+func TestMonitorCommandInvocation(t *testing.T) {
+	oldInterval := pollInterval
+	pollInterval = 5 * time.Millisecond
+	defer func() { pollInterval = oldInterval }()
+
+	t.Run("polls until success", func(t *testing.T) {
+		calls := 0
+		f := &fakeSSM{getCommandInvocation: func(*ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error) {
+			calls++
+			if calls == 1 {
+				return &ssm.GetCommandInvocationOutput{
+					Status:     ssmtypes.CommandInvocationStatusInProgress,
+					InstanceId: aws.String("i-1"),
+				}, nil
+			}
+			return &ssm.GetCommandInvocationOutput{
+				Status:                ssmtypes.CommandInvocationStatusSuccess,
+				InstanceId:            aws.String("i-1"),
+				StandardOutputContent: aws.String("ok"),
+			}, nil
+		}}
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		monitorCommandInvocation(context.Background(), f, &ssm.GetCommandInvocationInput{}, wg)
+		wg.Wait()
+
+		if calls < 2 {
+			t.Errorf("expected at least 2 polls, got %d", calls)
+		}
+	})
+
+	t.Run("stops on failed status", func(t *testing.T) {
+		f := &fakeSSM{getCommandInvocation: func(*ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:               ssmtypes.CommandInvocationStatusFailed,
+				InstanceId:           aws.String("i-1"),
+				StandardErrorContent: aws.String("boom"),
+			}, nil
+		}}
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		monitorCommandInvocation(context.Background(), f, &ssm.GetCommandInvocationInput{}, wg)
+		wg.Wait()
+	})
+
+	t.Run("stops on API error", func(t *testing.T) {
+		f := &fakeSSM{getCommandInvocation: func(*ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error) {
+			return nil, errors.New("api down")
+		}}
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		monitorCommandInvocation(context.Background(), f, &ssm.GetCommandInvocationInput{}, wg)
+		wg.Wait()
+	})
+}
+
+func TestGenerateSSHExecCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		exec     string
+		identity string
+		user     string
+		domain   string
+		want     string
+	}{
+		{"default command", "", "", "ec2-user", "host.example.com", "ec2-user@host.example.com"},
+		{"explicit command", "ls -la remote:", "", "u", "d", "ls -la remote:"},
+		{"identity added", "", "~/.ssh/key.pem", "root", "host", "-i ~/.ssh/key.pem root@host"},
+		{"identity already present", "ssh -i /k u@h", "/other", "u", "h", "ssh -i /k u@h"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateSSHExecCommand(tt.exec, tt.identity, tt.user, tt.domain)
+			if got != tt.want {
+				t.Errorf("GenerateSSHExecCommand(%q, %q, %q, %q) = %q, want %q",
+					tt.exec, tt.identity, tt.user, tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func keys(m map[string]*Target) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, strings.ReplaceAll(k, "\t", "\\t"))
+	}
+	return out
+}


### PR DESCRIPTION
Closes #8.

## What changed

The old test files turned out to be empty stubs (`package cmd`, one line each), so this builds the suite from scratch, all runnable offline with `-race`.

**Mocking refactor** — `internal/ssm.go` now defines narrow `ec2API`/`ssmAPI` interfaces (satisfied by the real `*ec2.Client`/`*ssm.Client`). The exported `aws.Config`-taking functions are unchanged; they delegate to unexported cores that take the interfaces, and tests drive those with fakes.

**New tests**

- `internal/ssm_test.go`: instance discovery (SSM pagination, the 199-per-call EC2 batching, Name-tag display naming), instance-by-IP and domain-by-ID lookup across pages, region listing, `SendCommand` input construction, command-invocation polling (success/failure/API error), and SSH command generation
- `internal/escape_simple_test.go`: the `~.` escape detection table (line-start detection, `~~` literals, mid-line tildes, CR handling), `isWaitError`, and a real-process `terminateGracefully` test
- `internal/assets_test.go`: zip extraction (flat and AWS's nested `package.zip` layout), the embedded-plugin fallback, plugin info roundtrip, hashing, validation (including the chmod path), and download URL construction
- `internal/error_test.go`: `WrapError` nil handling and caller annotation
- `cmd/root_test.go`: `getAWSProfile` precedence (flag > env > default)

**Coverage floor in CI**: 25%, enforced after the test run. A ratchet, not a target — raise it as coverage grows.

## Coverage

Total went from effectively 0% to **27.5%** (internal: **36.9%**, cmd: 12.1%). The issue suggested 60%, but the remaining uncovered code is interactive prompts (survey), real process/session execution, and platform package extraction requiring `ar`/`rpm2cpio`/`pkgutil` — testing those needs deeper seams and is better done incrementally while raising the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
