### PR TITLE
feat: publish multi-arch container images to GHCR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 # Never run two releases at once, and never cancel one mid-publish.
 concurrency:
@@ -45,6 +46,16 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,24 @@ archives:
         formats: [zip]
 
 # Release notes are grouped by Conventional Commit type.
+dockers_v2:
+  - images:
+      - ghcr.io/ottramst/gossm
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: Interactive CLI for AWS SSM Session Manager
+      org.opencontainers.image.url: https://github.com/ottramst/gossm
+      org.opencontainers.image.source: https://github.com/ottramst/gossm
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: MIT
+
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
-FROM golang:alpine as builder
+# Used by GoReleaser's dockers_v2 section: prebuilt binaries are placed in
+# the build context under $TARGETPLATFORM (e.g. linux/amd64/gossm), so no Go
+# toolchain stage is needed.
+#
+# The base image must ship glibc and CA certificates: gossm extracts and runs
+# the AWS session-manager-plugin, which is dynamically linked against glibc
+# (scratch/alpine/distroless-static cannot run it).
+FROM gcr.io/distroless/base-debian12:latest
 
-WORKDIR /build
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/gossm /usr/local/bin/gossm
 
-ADD . .
-
-RUN apk update && apk add --no-cache \
-      git \
-      ca-certificates  \
-    && update-ca-certificates \
-    && CGO_ENABLED=0 go build -ldflags='-w -s -extldflags "-static"' -a -o /build/gossm .
-
-FROM scratch
-
-ENV PATH /go/bin
-
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /build/ /go/bin/
-
-CMD [ "/go/bin/gossm" ]
+ENTRYPOINT ["/usr/local/bin/gossm"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Homebrew is not supported yet.
 
 Download the latest release from the [releases page](https://github.com/ottramst/gossm/releases).
 
+### Container
+
+Multi-arch images (linux/amd64, linux/arm64) are published to GHCR on every release:
+
+```sh
+docker run --rm -it -v ~/.aws:/root/.aws ghcr.io/ottramst/gossm:latest start
+```
+
+AWS credentials must be provided to the container: mount `~/.aws` as shown, or pass
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_REGION` with `-e`. The `-it` flags are
+required for the interactive prompts and the session terminal.
+
 ## Usage
 
 ### Global Command Arguments


### PR DESCRIPTION
Closes #4.

## What this adds

- **GoReleaser `dockers_v2`** (the current replacement for the deprecated `dockers`/`docker_manifests`): builds `linux/amd64` + `linux/arm64` images during release, pushed to `ghcr.io/ottramst/gossm` as a single multi-arch manifest tagged `{version}` and `latest` (`latest` skipped for prereleases), with OCI labels and buildx SBOM attestations
- **Release workflow**: `packages: write` permission, GHCR login, QEMU + buildx setup (all SHA-pinned)
- **Dockerfile**: consumed by GoReleaser (`COPY $TARGETPLATFORM/gossm`), no Go build stage
- **Dependabot**: `docker` ecosystem added for base-image updates
- **README**: container usage section (mount `~/.aws` or pass `AWS_*` env vars; `-it` required)

## Bug found: the old image could never run a session

The AWS session-manager-plugin binary is **dynamically linked against glibc** (`interpreter /lib64/ld-linux-x86-64.so.2`), so the previous `scratch`-based image would have failed with "no such file or directory" the moment gossm tried to exec it. The base is now `gcr.io/distroless/base-debian12` (glibc + CA certificates, no shell).

## Verification

- `goreleaser check` clean (no deprecation warnings); actionlint passes
- Full local snapshot built both platform images in 15s
- `docker run ghcr.io/ottramst/gossm:latest-amd64 --version` → `gossm version v2.0.1-SNAPSHOT-7c917eb`
- The session-manager-plugin executes inside the image (prints `1.2.245.0`), proving the glibc base fix

Actual GHCR publishing happens on the next release — snapshot mode builds but never pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)