### PR TITLE
feat: add Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fine-grained PAT with contents:write on ottramst/homebrew-tap.
+          # The cask push is skipped gracefully when this is unset.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,11 @@
 
 version: 2
 
+# Pin SCM detection to GitHub: without this, GoReleaser infers the release
+# host from whichever token env var it finds (a stray GITLAB_TOKEN in a
+# local shell produces gitlab.com download URLs in the Homebrew cask).
+force_token: github
+
 before:
   hooks:
     - go mod tidy
@@ -42,6 +47,29 @@ archives:
         formats: [zip]
 
 # Release notes are grouped by Conventional Commit type.
+# Pushes the cask to ottramst/homebrew-tap. Skipped gracefully when the
+# HOMEBREW_TAP_TOKEN secret is not configured; "auto" skips prereleases.
+homebrew_casks:
+  - name: gossm
+    repository:
+      owner: ottramst
+      name: homebrew-tap
+      token: '{{ envOrDefault "HOMEBREW_TAP_TOKEN" "" }}'
+    homepage: https://github.com/ottramst/gossm
+    description: Interactive CLI for AWS SSM Session Manager
+    skip_upload: '{{ if envOrDefault "HOMEBREW_TAP_TOKEN" "" }}auto{{ else }}true{{ end }}'
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    # The release binaries are unsigned; clear the quarantine flag so
+    # Gatekeeper doesn't block the first run.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gossm"]
+          end
+
 dockers_v2:
   - images:
       - ghcr.io/ottramst/gossm

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ AWS Systems Manager Session Manager uses SSH protocol tunneling for secure commu
 
 ## Installation
 
-### Homebrew
+### Homebrew (macOS)
 
-Homebrew is not supported yet.
+```sh
+brew install --cask ottramst/tap/gossm
+```
+
+The cask is updated automatically on every release. Homebrew casks are
+macOS-only; on Linux use the [container image](#container) or a binary release.
 
 ### Download Binary
 


### PR DESCRIPTION
Closes #6.

## What this adds

- **`homebrew_casks` in GoReleaser**: on release, a cask is generated and pushed to [ottramst/homebrew-tap](https://github.com/ottramst/homebrew-tap) (repo created, README in place). Install with `brew install --cask ottramst/tap/gossm`.
- **Design decision**: GoReleaser deprecated the `brews` formula section in favor of casks. Casks are macOS-only, so the issue's Linuxbrew item is deliberately dropped — Linux users have binaries and the container image.
- **Graceful degradation**: the tap push is skipped (not failed) while the `HOMEBREW_TAP_TOKEN` secret is missing, and `auto` skips prereleases.
- **Gatekeeper**: a postflight hook clears `com.apple.quarantine` since the binaries are unsigned.
- **`force_token: github`**: local verification surfaced that GoReleaser infers the release host from whichever token env var it finds — a stray `GITLAB_TOKEN` in the shell produced *gitlab.com* download URLs in the cask. Pinned to GitHub so the environment can't influence it.

## One manual step required

The release workflow needs a token that can push to the tap repo. Create a **fine-grained PAT** scoped to `ottramst/homebrew-tap` with **Contents: read and write**, then:

```sh
gh secret set HOMEBREW_TAP_TOKEN --repo ottramst/gossm
```

Until then, releases succeed but skip the cask push.

## Verification

- `goreleaser check` + actionlint clean
- Local snapshot generates a correct cask: per-arch sha256s, GitHub release URLs, `binary "gossm"`, quarantine postflight
- Real `brew install` verification happens after the first release publishes a cask (needs macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)