### PR TITLE
ci: fix Homebrew cask token template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,10 +54,13 @@ homebrew_casks:
     repository:
       owner: ottramst
       name: homebrew-tap
-      token: '{{ envOrDefault "HOMEBREW_TAP_TOKEN" "" }}'
+      # .Env requires the variable to be DEFINED (the release workflow always
+      # defines it, empty when the secret is missing); envOrDefault is not
+      # available in the GoReleaser version the action resolves.
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://github.com/ottramst/gossm
     description: Interactive CLI for AWS SSM Session Manager
-    skip_upload: '{{ if envOrDefault "HOMEBREW_TAP_TOKEN" "" }}auto{{ else }}true{{ end }}'
+    skip_upload: "{{ if .Env.HOMEBREW_TAP_TOKEN }}auto{{ else }}true{{ end }}"
     commit_author:
       name: github-actions[bot]
       email: 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
The v3.0.0 release run failed at the last step (cask publish): `envOrDefault` is not a template function in the GoReleaser resolved by the action (2.18.0). Everything before it succeeded — tag, GitHub release, GHCR images. Plain `.Env.HOMEBREW_TAP_TOKEN` works because the workflow always defines the variable (empty when the secret is missing), and `skip_upload` still degrades gracefully. Escaped local snapshot verification because publish-time templates only evaluate when actually publishing.

After merging: the incomplete v3.0.0 release + tag will be deleted and the release re-run from the fixed master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)