### PR TITLE
fix: mfa command cannot renew credentials once they expire

### DIFF
--- a/cmd/mfa.go
+++ b/cmd/mfa.go
@@ -91,21 +91,25 @@ func getMFADevice(ctx context.Context, flagDevice string) (string, error) {
 		return device, nil
 	}
 
-	// If not specified, get the user's virtual MFA device
+	// If not specified, derive the virtual MFA device from the caller identity
 	client := sts.NewFromConfig(*credential.awsConfig)
 	identity, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get identity: %w", err)
 	}
 
-	// Extract username from ARN
-	arnParts := strings.Split(*identity.Arn, "/")
-	if len(arnParts) < 2 {
-		return "", fmt.Errorf("unexpected ARN format: %s", *identity.Arn)
-	}
-	username := arnParts[len(arnParts)-1]
+	return mfaSerialFromIdentity(aws.ToString(identity.Arn), aws.ToString(identity.Account))
+}
 
-	return fmt.Sprintf(virtualMFADevice, aws.ToString(identity.Account), username), nil
+// mfaSerialFromIdentity derives the virtual MFA device ARN from an IAM user
+// identity. Assumed roles and other identity types have no derivable device.
+func mfaSerialFromIdentity(identityArn, account string) (string, error) {
+	if !strings.Contains(identityArn, ":user/") {
+		return "", fmt.Errorf("cannot derive an MFA device from identity %q (not an IAM user); pass --device explicitly", identityArn)
+	}
+	parts := strings.Split(identityArn, "/")
+	username := parts[len(parts)-1]
+	return fmt.Sprintf(virtualMFADevice, account, username), nil
 }
 
 // getTemporaryCredentials gets temporary credentials using the MFA token

--- a/cmd/mfa_test.go
+++ b/cmd/mfa_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMFASerialFromIdentity(t *testing.T) {
+	tests := []struct {
+		name    string
+		arn     string
+		account string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "IAM user",
+			arn:     "arn:aws:iam::123456789012:user/alice",
+			account: "123456789012",
+			want:    "arn:aws:iam::123456789012:mfa/alice",
+		},
+		{
+			name:    "IAM user with path",
+			arn:     "arn:aws:iam::123456789012:user/engineering/bob",
+			account: "123456789012",
+			want:    "arn:aws:iam::123456789012:mfa/bob",
+		},
+		{
+			name:    "assumed role",
+			arn:     "arn:aws:sts::123456789012:assumed-role/admin/session-name",
+			account: "123456789012",
+			wantErr: true,
+		},
+		{
+			name:    "root identity",
+			arn:     "arn:aws:iam::123456789012:root",
+			account: "123456789012",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mfaSerialFromIdentity(tt.arn, tt.account)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				if !strings.Contains(err.Error(), "--device") {
+					t.Errorf("error %q should point the user at --device", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("mfaSerialFromIdentity(%q) = %q, want %q", tt.arn, got, tt.want)
+			}
+		})
+	}
+}
+
+// Regression test for #28: the MFA credentials file redirect must be
+// controllable, so the mfa command can skip it and renew with base
+// credentials.
+func TestApplyMFACredentialsFile(t *testing.T) {
+	oldPath := credentialWithMFA
+	t.Cleanup(func() { credentialWithMFA = oldPath })
+
+	mfaFile := filepath.Join(t.TempDir(), "credentials_mfa")
+	if err := os.WriteFile(mfaFile, []byte("[default]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("sets env when file exists and env is empty", func(t *testing.T) {
+		credentialWithMFA = mfaFile
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+		applyMFACredentialsFile()
+		if got := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); got != mfaFile {
+			t.Errorf("env = %q, want %q", got, mfaFile)
+		}
+	})
+
+	t.Run("respects an existing env value", func(t *testing.T) {
+		credentialWithMFA = mfaFile
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/custom/path")
+		applyMFACredentialsFile()
+		if got := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); got != "/custom/path" {
+			t.Errorf("env = %q, want untouched /custom/path", got)
+		}
+	})
+
+	t.Run("no-op when the file does not exist", func(t *testing.T) {
+		credentialWithMFA = filepath.Join(t.TempDir(), "missing")
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+		applyMFACredentialsFile()
+		if got := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); got != "" {
+			t.Errorf("env = %q, want empty", got)
+		}
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,24 +156,41 @@ func setupSsmPlugin(plugin []byte) {
 	}
 }
 
+// applyMFACredentialsFile points AWS_SHARED_CREDENTIALS_FILE at the gossm MFA
+// credentials file when it exists and the variable is not already set.
+func applyMFACredentialsFile() {
+	if _, err := os.Stat(credentialWithMFA); err == nil && os.Getenv("AWS_SHARED_CREDENTIALS_FILE") == "" {
+		color.Yellow("[Use] gossm default mfa credential file %s", credentialWithMFA)
+		_ = os.Setenv("AWS_SHARED_CREDENTIALS_FILE", credentialWithMFA)
+	}
+}
+
 // setupAWSCredentials sets up AWS credentials using the AWS SDK's credential chain
 func setupAWSCredentials(awsProfile, awsRegion string) {
 	// Validate the invoked subcommand before touching credentials
 	args := os.Args[1:]
-	_, _, err := rootCmd.Find(args)
+	subcmd, _, err := rootCmd.Find(args)
 	if err != nil {
 		logErrorAndExit(internal.WrapError(err))
 	}
+	isMFA := subcmd.Name() == "mfa"
 
-	// Check for special MFA credentials file
-	if _, err := os.Stat(credentialWithMFA); err == nil && os.Getenv("AWS_SHARED_CREDENTIALS_FILE") == "" {
-		color.Yellow("[Use] gossm default mfa credential file %s", credentialWithMFA)
-		_ = os.Setenv("AWS_SHARED_CREDENTIALS_FILE", credentialWithMFA)
+	// Point the SDK at the MFA credentials file when one exists — except for
+	// the mfa command itself, which must authenticate with base credentials
+	// or renewing expired temporary credentials becomes impossible.
+	if !isMFA {
+		applyMFACredentialsFile()
 	}
 
 	// Use AWS SDK's built-in credential chain with our profile
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithSharedConfigProfile(credential.awsProfile),
+	}
+	if isMFA {
+		// Force base credentials even if the user exported
+		// AWS_SHARED_CREDENTIALS_FILE pointing at the MFA file.
+		configOpts = append(configOpts,
+			config.WithSharedCredentialsFiles([]string{config.DefaultSharedCredentialsFilename()}))
 	}
 
 	// Add region if specified


### PR DESCRIPTION
Closes #28.

## The bug

`initConfig` redirects `AWS_SHARED_CREDENTIALS_FILE` to `~/.aws/credentials_mfa` whenever the file exists — for every command, **including `mfa` itself**. Once the temporary credentials expire, `gossm mfa <code>` authenticates with the expired credentials and STS rejects it; the user is stuck until they delete the file or override the env var. (Upstream left an empty placeholder branch for exactly this case — removed as dead code in #20.)

## The fix — two layers

1. The `mfa` command skips the automatic redirect (`applyMFACredentialsFile`, now extracted and unit-tested).
2. It also loads base credentials explicitly via `config.WithSharedCredentialsFiles` — covering users who permanently exported `AWS_SHARED_CREDENTIALS_FILE` in their shell, which our own README recommends.

## Also fixed

`getMFADevice` derived the MFA serial from the caller-identity ARN assuming an IAM user; for assumed-role or root identities it built a bogus serial. The extracted `mfaSerialFromIdentity` helper now returns a clear error pointing at `--device` (table-tested: user, user-with-path, assumed-role, root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)