### PR TITLE
fix: ssh/scp direct mode rejects instance IDs and private-only instances

### DIFF
--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/fatih/color"
+	"github.com/kballard/go-shellquote"
 	"github.com/spf13/cobra"
 
 	"github.com/ottramst/gossm/internal"
@@ -93,10 +93,13 @@ func validateSCPArguments(flagExec string) (string, error) {
 		return "", errors.New("SCP command arguments are required")
 	}
 
-	// Basic validation of SCP arguments
-	parts := strings.Split(scpArgs, " ")
+	// Basic validation of SCP arguments, respecting quoted segments
+	parts, err := shellquote.Split(scpArgs)
+	if err != nil {
+		return "", fmt.Errorf("invalid SCP arguments: %w", err)
+	}
 	if len(parts) < 2 {
-		return "", fmt.Errorf("invalid SCP arguments: must include source and destination")
+		return "", errors.New("invalid SCP arguments: must include source and destination")
 	}
 
 	return scpArgs, nil
@@ -104,56 +107,36 @@ func validateSCPArguments(flagExec string) (string, error) {
 
 // findTargetInstanceID identifies the instance ID for the SCP operation
 func findTargetInstanceID(ctx context.Context, scpArgs string) (string, error) {
-	// Split the arguments to identify source and destination
-	parts := strings.Split(scpArgs, " ")
-	dst := parts[len(parts)-1]
-	src := parts[len(parts)-2]
-
-	// Parse to find the host part (could be in source or destination)
-	var hostname string
-
-	// Check destination for hostname (user@host:path format)
-	dstParts := strings.Split(dst, ":")
-	if len(dstParts) > 1 {
-		hostParts := strings.Split(dstParts[0], "@")
-		if len(hostParts) == 2 {
-			hostname = hostParts[1]
-		}
-	}
-
-	// If not found in destination, check source
-	if hostname == "" {
-		srcParts := strings.Split(src, ":")
-		if len(srcParts) > 1 {
-			hostParts := strings.Split(srcParts[0], "@")
-			if len(hostParts) == 2 {
-				hostname = hostParts[1]
-			}
-		}
-	}
-
-	if hostname == "" {
-		return "", fmt.Errorf("could not identify target hostname in SCP arguments")
-	}
-
-	// Resolve hostname to IP address
-	ips, err := net.LookupIP(hostname)
-	if err != nil || len(ips) == 0 {
-		return "", fmt.Errorf("failed to resolve hostname '%s': %w", hostname, err)
-	}
-
-	// Find instance ID based on IP address
-	ip := ips[0].String()
-	instanceID, err := internal.FindInstanceIdByIp(ctx, *credential.awsConfig, ip)
+	parts, err := shellquote.Split(scpArgs)
 	if err != nil {
-		return "", fmt.Errorf("failed to find instance by IP '%s': %w", ip, err)
+		return "", fmt.Errorf("invalid SCP arguments: %w", err)
 	}
 
-	if instanceID == "" {
-		return "", fmt.Errorf("no matching instance found for IP '%s'", ip)
+	hostname, err := hostFromSCPArgs(parts)
+	if err != nil {
+		return "", err
 	}
 
-	return instanceID, nil
+	return resolveTargetHost(ctx, hostname)
+}
+
+// hostFromSCPArgs extracts the remote host (user@host:path) from parsed scp
+// arguments, checking the destination first and then the source.
+func hostFromSCPArgs(parts []string) (string, error) {
+	if len(parts) < 2 {
+		return "", errors.New("invalid SCP arguments: must include source and destination")
+	}
+	for _, arg := range []string{parts[len(parts)-1], parts[len(parts)-2]} {
+		segs := strings.Split(arg, ":")
+		if len(segs) < 2 {
+			continue
+		}
+		hostParts := strings.Split(segs[0], "@")
+		if len(hostParts) == 2 && hostParts[1] != "" {
+			return hostParts[1], nil
+		}
+	}
+	return "", errors.New("could not identify target hostname in SCP arguments")
 }
 
 // displaySCPCommandInfo shows information about the SCP operation
@@ -209,13 +192,12 @@ func executeSCPCommand(scpArgs string, session *ssm.StartSessionOutput, targetIn
 		string(paramsJSON),
 	)
 
-	// Build SCP command arguments
-	args := []string{"-o", proxyCommand}
-	for arg := range strings.FieldsSeq(scpArgs) {
-		if arg != "" {
-			args = append(args, arg)
-		}
+	// Build SCP command arguments, respecting quoted segments
+	parsedArgs, err := shellquote.Split(scpArgs)
+	if err != nil {
+		return fmt.Errorf("invalid SCP arguments: %w", err)
 	}
+	args := append([]string{"-o", proxyCommand}, parsedArgs...)
 
 	// Execute SCP command
 	return internal.CallProcess("scp", args...)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/fatih/color"
+	"github.com/kballard/go-shellquote"
 	"github.com/spf13/cobra"
 
 	"github.com/ottramst/gossm/internal"
@@ -106,49 +108,80 @@ func handleInteractiveSSH(ctx context.Context, identityFlag string) (string, str
 	}
 
 	// Generate SSH command
-	sshCommand := internal.GenerateSSHExecCommand("", identityFlag, sshUser.Name, target.PublicDomain)
+	sshCommand := internal.GenerateSSHExecCommand("", identityFlag, sshUser.Name, sshHostForTarget(target))
 
 	return sshCommand, target.Name, nil
 }
 
+// sshHostForTarget picks the host to place on the SSH command line: the
+// public DNS name when present, otherwise the instance ID — the SSM
+// ProxyCommand tunnels by instance ID either way.
+func sshHostForTarget(target *internal.Target) string {
+	if target.PublicDomain != "" {
+		return target.PublicDomain
+	}
+	return target.Name
+}
+
 // handleDirectSSHCommand processes a directly specified SSH command
 func handleDirectSSHCommand(ctx context.Context, execFlag string) (string, string, error) {
-	// Parse the exec command to extract the server
-	parts := strings.Split(execFlag, " ")
-
-	// The server should be the last part of the command (user@server)
-	lastPart := parts[len(parts)-1]
-	serverParts := strings.Split(lastPart, "@")
-
-	if len(serverParts) < 2 {
-		return "", "", fmt.Errorf("invalid SSH command format: must include user@server")
-	}
-
-	// Extract server hostname
-	server := serverParts[len(serverParts)-1]
-
-	// Resolve server to IP
-	ips, err := net.LookupIP(server)
-	if err != nil || len(ips) == 0 {
-		return "", "", fmt.Errorf("failed to resolve hostname '%s': %w", server, err)
-	}
-
-	ip := ips[0].String()
-
-	// Find instance by IP
-	instanceID, err := internal.FindInstanceIdByIp(ctx, *credential.awsConfig, ip)
+	parts, err := shellquote.Split(execFlag)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to find instance by IP '%s': %w", ip, err)
+		return "", "", fmt.Errorf("invalid SSH command: %w", err)
 	}
 
-	if instanceID == "" {
-		return "", "", fmt.Errorf("no matching instance found for IP '%s'", ip)
+	host, err := hostFromSSHArgs(parts)
+	if err != nil {
+		return "", "", err
+	}
+
+	instanceID, err := resolveTargetHost(ctx, host)
+	if err != nil {
+		return "", "", err
 	}
 
 	// Generate SSH command
 	sshCommand := internal.GenerateSSHExecCommand(execFlag, "", "", "")
 
 	return sshCommand, instanceID, nil
+}
+
+// hostFromSSHArgs extracts the host from parsed SSH arguments; the last
+// argument must be user@host.
+func hostFromSSHArgs(parts []string) (string, error) {
+	if len(parts) == 0 {
+		return "", errors.New("invalid SSH command format: must include user@server")
+	}
+	lastPart := parts[len(parts)-1]
+	serverParts := strings.Split(lastPart, "@")
+	if len(serverParts) < 2 || serverParts[len(serverParts)-1] == "" {
+		return "", errors.New("invalid SSH command format: must include user@server")
+	}
+	return serverParts[len(serverParts)-1], nil
+}
+
+// resolveTargetHost resolves an ssh/scp destination host to an EC2 instance
+// ID: instance IDs are used directly, anything else is resolved via DNS and
+// matched against running instances by IP.
+func resolveTargetHost(ctx context.Context, host string) (string, error) {
+	if strings.HasPrefix(host, "i-") || strings.HasPrefix(host, "mi-") {
+		return host, nil
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil || len(ips) == 0 {
+		return "", fmt.Errorf("failed to resolve hostname '%s': %w", host, err)
+	}
+	ip := ips[0].String()
+
+	instanceID, err := internal.FindInstanceIdByIp(ctx, *credential.awsConfig, ip)
+	if err != nil {
+		return "", fmt.Errorf("failed to find instance by IP '%s': %w", ip, err)
+	}
+	if instanceID == "" {
+		return "", fmt.Errorf("no matching instance found for IP '%s'", ip)
+	}
+	return instanceID, nil
 }
 
 // executeSSHCommand executes the SSH command with SSM as proxy
@@ -182,13 +215,12 @@ func executeSSHCommand(sshArgs string, session *ssm.StartSessionOutput, targetNa
 		string(paramsJSON),
 	)
 
-	// Build SSH command arguments
-	cmdArgs := []string{"-o", proxyCommand}
-	for arg := range strings.FieldsSeq(sshArgs) {
-		if arg != "" {
-			cmdArgs = append(cmdArgs, arg)
-		}
+	// Build SSH command arguments, respecting quoted segments
+	parsedArgs, err := shellquote.Split(sshArgs)
+	if err != nil {
+		return fmt.Errorf("invalid SSH arguments: %w", err)
 	}
+	cmdArgs := append([]string{"-o", proxyCommand}, parsedArgs...)
 
 	// Execute SSH command
 	return internal.CallProcess("ssh", cmdArgs...)

--- a/cmd/ssh_scp_test.go
+++ b/cmd/ssh_scp_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ottramst/gossm/internal"
+)
+
+func TestHostFromSSHArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		parts   []string
+		want    string
+		wantErr bool
+	}{
+		{"instance id", []string{"ec2-user@i-1234567890abcdef0"}, "i-1234567890abcdef0", false},
+		{"hostname with flags", []string{"-i", "key.pem", "user@host.example.com"}, "host.example.com", false},
+		{"no user prefix", []string{"justhost"}, "", true},
+		{"empty host", []string{"user@"}, "", true},
+		{"empty args", []string{}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hostFromSSHArgs(tt.parts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("hostFromSSHArgs(%v) error = %v, wantErr %v", tt.parts, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("hostFromSSHArgs(%v) = %q, want %q", tt.parts, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostFromSCPArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		parts   []string
+		want    string
+		wantErr bool
+	}{
+		{"remote destination", []string{"file.txt", "user@i-123:/home/user/"}, "i-123", false},
+		{"remote source", []string{"user@host.internal:/etc/config", "local.txt"}, "host.internal", false},
+		{"with flags before paths", []string{"-r", "dir", "user@i-456:/data"}, "i-456", false},
+		{"no remote side", []string{"a.txt", "b.txt"}, "", true},
+		{"windows-style path is not a host", []string{"C:\\file.txt", "dest.txt"}, "", true},
+		{"too few args", []string{"only-one"}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hostFromSCPArgs(tt.parts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("hostFromSCPArgs(%v) error = %v, wantErr %v", tt.parts, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("hostFromSCPArgs(%v) = %q, want %q", tt.parts, got, tt.want)
+			}
+		})
+	}
+}
+
+// Regression test for #29: instance IDs must be used directly, never DNS
+// resolved (the documented `gossm ssh -e "user@i-..."` form used to fail
+// with a DNS error).
+func TestResolveTargetHostInstanceID(t *testing.T) {
+	for _, id := range []string{"i-1234567890abcdef0", "mi-0123456789abcdef0"} {
+		got, err := resolveTargetHost(context.Background(), id)
+		if err != nil {
+			t.Fatalf("resolveTargetHost(%q) returned error: %v", id, err)
+		}
+		if got != id {
+			t.Errorf("resolveTargetHost(%q) = %q, want the ID unchanged", id, got)
+		}
+	}
+}
+
+func TestSSHHostForTarget(t *testing.T) {
+	withPublic := &internal.Target{Name: "i-1", PublicDomain: "pub.example.com"}
+	if got := sshHostForTarget(withPublic); got != "pub.example.com" {
+		t.Errorf("sshHostForTarget = %q, want public DNS name", got)
+	}
+
+	privateOnly := &internal.Target{Name: "i-2"}
+	if got := sshHostForTarget(privateOnly); got != "i-2" {
+		t.Errorf("sshHostForTarget = %q, want instance ID fallback", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
 	github.com/fatih/color v1.19.0
 	github.com/gjbae1212/go-wraperror v0.7.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	golang.org/x/term v0.45.0
@@ -33,7 +34,6 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect


### PR DESCRIPTION
Closes #29.

## The bugs

1. The README's own example — `gossm ssh -e "ec2-user@i-1234567890abcdef0"` — could never work: the code DNS-resolved every host, and instance IDs don't resolve.
2. Interactive ssh built `user@<PublicDomain>`; for private-only instances that's `user@` and the connection failed, even though the SSM proxy tunnels by instance ID regardless.
3. `strings.Split(args, " ")` broke quoted paths containing spaces.

## The fix

- `resolveTargetHost` (shared by ssh and scp): `i-`/`mi-` prefixed hosts are used directly; anything else goes DNS → `FindInstanceIdByIp` as before.
- Interactive ssh falls back to the instance ID when no public DNS name exists (`sshHostForTarget`).
- All argument parsing/building uses `shellquote` (promoted from indirect to direct dependency), so quoted segments survive.
- Host extraction is in pure, table-tested helpers (`hostFromSSHArgs`, `hostFromSCPArgs`) — including a regression test asserting instance IDs never hit DNS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)