### PR TITLE
perf: embed only the current platform's session-manager-plugin

### DIFF
--- a/internal/assets.go
+++ b/internal/assets.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
-	"embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,11 +17,6 @@ import (
 	"strings"
 	"time"
 )
-
-// Keep embed directive for fallback if download fails
-//
-//go:embed assets/*
-var assets embed.FS
 
 const (
 	// defaultPluginVersion is used when no specific version is requested
@@ -119,34 +113,21 @@ func GetPluginDirectory() string {
 	return filepath.Join(homeDir, ".gossm", "plugins")
 }
 
-// getEmbeddedPlugin extracts the plugin from embedded assets
+// getEmbeddedPlugin installs the plugin bundled into this build. Only the
+// current platform's plugin is embedded — see the embed_*.go files.
 func getEmbeddedPlugin(pluginDir string) ([]byte, error) {
-	goos := strings.ToLower(runtime.GOOS)
-	goarch := strings.ToLower(runtime.GOARCH)
-
-	// Windows ARM64 uses the AMD64 binary (via emulation)
-	if goos == "windows" && goarch == "arm64" {
-		goarch = "amd64"
-	}
-
-	pluginKey := fmt.Sprintf("plugin/%s_%s/%s",
-		goos,
-		goarch,
-		GetSsmPluginName())
-
-	data, err := assets.ReadFile("assets/" + pluginKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract embedded plugin: %w", err)
+	if len(embeddedPlugin) == 0 {
+		return nil, fmt.Errorf("no embedded session-manager-plugin for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 
 	// Write plugin to disk
 	pluginPath := filepath.Join(pluginDir, GetSsmPluginName())
-	if err := os.WriteFile(pluginPath, data, 0755); err != nil {
+	if err := os.WriteFile(pluginPath, embeddedPlugin, 0755); err != nil {
 		return nil, fmt.Errorf("failed to write plugin file: %w", err)
 	}
 
 	// Calculate hash
-	hash, _ := calculateHash(data)
+	hash, _ := calculateHash(embeddedPlugin)
 
 	// Save plugin info
 	info := PluginInfo{
@@ -159,7 +140,7 @@ func getEmbeddedPlugin(pluginDir string) ([]byte, error) {
 		return nil, err
 	}
 
-	return data, nil
+	return embeddedPlugin, nil
 }
 
 // downloadPlugin downloads and installs the specified plugin version

--- a/internal/embed_darwin_amd64.go
+++ b/internal/embed_darwin_amd64.go
@@ -1,0 +1,11 @@
+//go:build darwin && amd64
+
+package internal
+
+import _ "embed"
+
+// embeddedPlugin is the session-manager-plugin bundled for this build's
+// platform, used as a fallback when downloading the plugin fails.
+//
+//go:embed assets/plugin/darwin_amd64/session-manager-plugin
+var embeddedPlugin []byte

--- a/internal/embed_darwin_arm64.go
+++ b/internal/embed_darwin_arm64.go
@@ -1,0 +1,11 @@
+//go:build darwin && arm64
+
+package internal
+
+import _ "embed"
+
+// embeddedPlugin is the session-manager-plugin bundled for this build's
+// platform, used as a fallback when downloading the plugin fails.
+//
+//go:embed assets/plugin/darwin_arm64/session-manager-plugin
+var embeddedPlugin []byte

--- a/internal/embed_linux_amd64.go
+++ b/internal/embed_linux_amd64.go
@@ -1,0 +1,11 @@
+//go:build linux && amd64
+
+package internal
+
+import _ "embed"
+
+// embeddedPlugin is the session-manager-plugin bundled for this build's
+// platform, used as a fallback when downloading the plugin fails.
+//
+//go:embed assets/plugin/linux_amd64/session-manager-plugin
+var embeddedPlugin []byte

--- a/internal/embed_linux_arm64.go
+++ b/internal/embed_linux_arm64.go
@@ -1,0 +1,11 @@
+//go:build linux && arm64
+
+package internal
+
+import _ "embed"
+
+// embeddedPlugin is the session-manager-plugin bundled for this build's
+// platform, used as a fallback when downloading the plugin fails.
+//
+//go:embed assets/plugin/linux_arm64/session-manager-plugin
+var embeddedPlugin []byte

--- a/internal/embed_other.go
+++ b/internal/embed_other.go
@@ -1,0 +1,7 @@
+//go:build !(linux && (amd64 || arm64)) && !(darwin && (amd64 || arm64)) && !windows
+
+package internal
+
+// embeddedPlugin is empty on platforms without a bundled
+// session-manager-plugin; downloading is the only option there.
+var embeddedPlugin []byte

--- a/internal/embed_windows.go
+++ b/internal/embed_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package internal
+
+import _ "embed"
+
+// embeddedPlugin is the session-manager-plugin bundled for this build's
+// platform, used as a fallback when downloading the plugin fails.
+// AWS ships only an amd64 plugin for Windows; arm64 runs it via emulation.
+//
+//go:embed assets/plugin/windows_amd64/session-manager-plugin.exe
+var embeddedPlugin []byte


### PR DESCRIPTION
Closes #30.

## Change

`//go:embed assets/*` embedded all five platform plugins (~53 MB) into every binary. Now one build-tagged `embed_*.go` file per target embeds exactly the plugin that build can run:

- linux/amd64, linux/arm64, darwin/amd64, darwin/arm64: their own plugin
- windows (any arch): the amd64 plugin — AWS ships no arm64 Windows plugin; emulation ran it before and still does
- anything else: empty fallback with a clear "no embedded plugin for GOOS/GOARCH" error; downloading remains their path

`getEmbeddedPlugin` lost its runtime GOOS/GOARCH key mapping — the selection is now compile-time.

## Measured result (linux/amd64, release flags `-trimpath -ldflags "-s -w"`)

| | |
|---|---|
| master | **89.0 MB** |
| this branch | **57.7 MB** (−31.3 MB, −35%) |

Honest correction to the issue's ~75% estimate: that arithmetic used a stale pre-dependency-bump baseline. Symbol-table analysis shows the remaining binary is dominated by **code** — ~30 MB of `.text` (mostly the generated `aws-sdk-go-v2/service/ec2` package) plus ~10 MB of Go pclntab — with the single embedded plugin contributing only 10.3 MB. The foreign-plugin dedup itself is fully realized; the rest of the weight isn't plugin-related. (Also investigated: the scary 32 MB `crypto/internal/fips140/drbg.memory` symbol lives in `.noptrbss` — virtual memory only, zero file bytes.)

Container images and Homebrew/binary downloads all shrink by the same ~31 MB.

## Verification

- All five targets build; lint and race tests pass (`TestGetEmbeddedPlugin` exercises the new path)
- Per-target release-style builds: 50–58 MB each (was 82–89 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)