### PR TITLE
refactor: deduplicate command scaffolding in cmd/

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -30,31 +30,16 @@ var (
 	}
 )
 
-// findSpecificTarget looks for a specific target by name
-func findSpecificTarget(ctx context.Context, targetName string) ([]*internal.Target, error) {
-	// Get all available instances
-	allInstances, err := internal.FindInstances(ctx, *credential.awsConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// Find the specified target
-	for _, instance := range allInstances {
-		if instance.Name == targetName {
-			return []*internal.Target{instance}, nil
-		}
-	}
-
-	// If we get here, the specified target wasn't found
-	return nil, fmt.Errorf("target instance '%s' not found", targetName)
-}
-
 // findTargetInstances identifies the instances to target for command
 // execution, using the given flag value or prompting when it is empty
 func findTargetInstances(ctx context.Context, flagTarget string) ([]*internal.Target, error) {
 	argTarget := strings.TrimSpace(flagTarget)
 	if argTarget != "" {
-		return findSpecificTarget(ctx, argTarget)
+		target, err := findSpecificInstance(ctx, argTarget)
+		if err != nil {
+			return nil, err
+		}
+		return []*internal.Target{target}, nil
 	}
 
 	// If no specific target, prompt user to select targets

--- a/cmd/fwd.go
+++ b/cmd/fwd.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/ottramst/gossm/internal"
@@ -114,53 +112,14 @@ func portConfiguration(flagRemote, flagLocal string) (localPort, remotePort stri
 
 // startPortForwardingSession creates and starts an SSM port forwarding session
 func startPortForwardingSession(ctx context.Context, target *internal.Target, localPort, remotePort string) error {
-	// Prepare SSM input for port forwarding
-	sessionInput := &ssm.StartSessionInput{
+	return runPluginSession(ctx, &ssm.StartSessionInput{
 		DocumentName: aws.String(documentNamePortForwarding),
 		Parameters: map[string][]string{
 			"portNumber":      {remotePort},
 			"localPortNumber": {localPort},
 		},
 		Target: aws.String(target.Name),
-	}
-
-	// Create the session
-	session, err := internal.CreateStartSession(ctx, *credential.awsConfig, sessionInput)
-	if err != nil {
-		return fmt.Errorf("failed to create session: %w", err)
-	}
-
-	// Marshal session and parameters to JSON for the SSM plugin
-	sessionJSON, err := json.Marshal(session)
-	if err != nil {
-		return fmt.Errorf("failed to marshal session: %w", err)
-	}
-
-	paramsJSON, err := json.Marshal(sessionInput)
-	if err != nil {
-		return fmt.Errorf("failed to marshal parameters: %w", err)
-	}
-
-	// Call the SSM plugin to start the port forwarding
-	if err := internal.CallProcess(
-		credential.ssmPluginPath,
-		string(sessionJSON),
-		credential.awsConfig.Region,
-		"StartSession",
-		credential.awsProfile,
-		string(paramsJSON),
-	); err != nil {
-		color.Red("[err] %v", err.Error())
-	}
-
-	// Clean up by terminating the session
-	if err := internal.DeleteStartSession(ctx, *credential.awsConfig, &ssm.TerminateSessionInput{
-		SessionId: session.SessionId,
-	}); err != nil {
-		return fmt.Errorf("failed to terminate session: %w", err)
-	}
-
-	return nil
+	})
 }
 
 func init() {

--- a/cmd/fwdrem.go
+++ b/cmd/fwdrem.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/ottramst/gossm/internal"
@@ -83,8 +81,7 @@ func getRemoteHost(flagHost string) (string, error) {
 
 // startRemoteHostPortForwardingSession creates and starts an SSM port forwarding session to a remote host
 func startRemoteHostPortForwardingSession(ctx context.Context, target *internal.Target, localPort, remotePort, host string) error {
-	// Prepare SSM input for port forwarding
-	sessionInput := &ssm.StartSessionInput{
+	return runPluginSession(ctx, &ssm.StartSessionInput{
 		DocumentName: aws.String(documentNameRemotePortForwarding),
 		Parameters: map[string][]string{
 			"portNumber":      {remotePort},
@@ -92,45 +89,7 @@ func startRemoteHostPortForwardingSession(ctx context.Context, target *internal.
 			"host":            {host},
 		},
 		Target: aws.String(target.Name),
-	}
-
-	// Create the session
-	session, err := internal.CreateStartSession(ctx, *credential.awsConfig, sessionInput)
-	if err != nil {
-		return fmt.Errorf("failed to create session: %w", err)
-	}
-
-	// Marshal session and parameters to JSON for the SSM plugin
-	sessionJSON, err := json.Marshal(session)
-	if err != nil {
-		return fmt.Errorf("failed to marshal session: %w", err)
-	}
-
-	paramsJSON, err := json.Marshal(sessionInput)
-	if err != nil {
-		return fmt.Errorf("failed to marshal parameters: %w", err)
-	}
-
-	// Call the SSM plugin to start the port forwarding
-	if err := internal.CallProcess(
-		credential.ssmPluginPath,
-		string(sessionJSON),
-		credential.awsConfig.Region,
-		"StartSession",
-		credential.awsProfile,
-		string(paramsJSON),
-	); err != nil {
-		color.Red("[err] %v", err.Error())
-	}
-
-	// Clean up by terminating the session
-	if err := internal.DeleteStartSession(ctx, *credential.awsConfig, &ssm.TerminateSessionInput{
-		SessionId: session.SessionId,
-	}); err != nil {
-		return fmt.Errorf("failed to terminate session: %w", err)
-	}
-
-	return nil
+	})
 }
 
 // init initializes the fwdrem command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,7 +184,7 @@ func setupAWSCredentials(awsProfile, awsRegion string) {
 
 	// Use AWS SDK's built-in credential chain with our profile
 	configOpts := []func(*config.LoadOptions) error{
-		config.WithSharedConfigProfile(credential.awsProfile),
+		config.WithSharedConfigProfile(awsProfile),
 	}
 	if isMFA {
 		// Force base credentials even if the user exported

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -73,7 +72,7 @@ func runSCPCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// Execute SCP command with SSM as proxy
-	err = executeSCPCommand(scpArgs, session, targetInstanceID)
+	err = runProxiedCommand("scp", scpArgs, session, sshSessionInput(targetInstanceID))
 	if err != nil {
 		color.Red("%v", err)
 	}
@@ -145,62 +144,24 @@ func displaySCPCommandInfo(scpArgs, targetInstanceID string) {
 	color.Cyan("scp %s", scpArgs)
 }
 
-// startSSHSession starts an SSH session through SSM
-func startSSHSession(ctx context.Context, targetInstanceID string) (*ssm.StartSessionOutput, error) {
-	input := &ssm.StartSessionInput{
+// sshSessionInput builds the SSM session input for tunneling SSH (and SCP)
+// to the given instance.
+func sshSessionInput(targetInstanceID string) *ssm.StartSessionInput {
+	return &ssm.StartSessionInput{
 		DocumentName: aws.String(documentNameSSH),
 		Parameters:   map[string][]string{"portNumber": {defaultSSHPort}},
 		Target:       aws.String(targetInstanceID),
 	}
+}
 
-	session, err := internal.CreateStartSession(ctx, *credential.awsConfig, input)
+// startSSHSession starts an SSH session through SSM
+func startSSHSession(ctx context.Context, targetInstanceID string) (*ssm.StartSessionOutput, error) {
+	session, err := internal.CreateStartSession(ctx, *credential.awsConfig, sshSessionInput(targetInstanceID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SSM session: %w", err)
 	}
 
 	return session, nil
-}
-
-// executeSCPCommand executes the SCP command with SSM as proxy
-func executeSCPCommand(scpArgs string, session *ssm.StartSessionOutput, targetInstanceID string) error {
-	// Marshal session information to JSON
-	sessionJSON, err := json.Marshal(session)
-	if err != nil {
-		return fmt.Errorf("failed to marshal session data: %w", err)
-	}
-
-	// Create parameter input for the SSM plugin
-	input := &ssm.StartSessionInput{
-		DocumentName: aws.String(documentNameSSH),
-		Parameters:   map[string][]string{"portNumber": {defaultSSHPort}},
-		Target:       aws.String(targetInstanceID),
-	}
-
-	// Marshal parameters to JSON
-	paramsJSON, err := json.Marshal(input)
-	if err != nil {
-		return fmt.Errorf("failed to marshal session parameters: %w", err)
-	}
-
-	// Build proxy command for SCP
-	proxyCommand := fmt.Sprintf("ProxyCommand=%s '%s' %s %s %s '%s'",
-		credential.ssmPluginPath,
-		string(sessionJSON),
-		credential.awsConfig.Region,
-		"StartSession",
-		credential.awsProfile,
-		string(paramsJSON),
-	)
-
-	// Build SCP command arguments, respecting quoted segments
-	parsedArgs, err := shellquote.Split(scpArgs)
-	if err != nil {
-		return fmt.Errorf("invalid SCP arguments: %w", err)
-	}
-	args := append([]string{"-o", proxyCommand}, parsedArgs...)
-
-	// Execute SCP command
-	return internal.CallProcess("scp", args...)
 }
 
 func init() {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -49,62 +49,44 @@ func runStartSession(cmd *cobra.Command, args []string) {
 	// Display information
 	internal.PrintReady("start-session", credential.awsConfig.Region, target.Name)
 
-	// Start session
-	session, err := createSession(ctx, target.Name)
-	if err != nil {
-		logErrorAndExit(err)
-	}
-
-	// Execute session
-	if err := executeSession(session, target.Name); err != nil {
-		color.Red("%v", err)
-	}
-
-	// Clean up
-	if err := terminateSession(ctx, session.SessionId); err != nil {
+	// Run the interactive session through the SSM plugin
+	if err := runPluginSession(ctx, &ssm.StartSessionInput{
+		Target: aws.String(target.Name),
+	}); err != nil {
 		logErrorAndExit(err)
 	}
 }
 
-// createSession creates a new SSM session to the target instance
-func createSession(ctx context.Context, targetName string) (*ssm.StartSessionOutput, error) {
-	input := &ssm.StartSessionInput{
-		Target: aws.String(targetName),
-	}
-
+// runPluginSession creates an SSM session from the given input, drives the
+// session-manager-plugin with it, and terminates the session afterwards.
+// It is shared by the start, fwd, and fwdrem commands.
+func runPluginSession(ctx context.Context, input *ssm.StartSessionInput) error {
 	session, err := internal.CreateStartSession(ctx, *credential.awsConfig, input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create session: %w", err)
+		return fmt.Errorf("failed to create session: %w", err)
 	}
 
-	return session, nil
-}
-
-// executeSession executes the interactive session using the SSM plugin
-func executeSession(session *ssm.StartSessionOutput, targetName string) error {
-	// Marshal session to JSON
 	sessionJSON, err := json.Marshal(session)
 	if err != nil {
 		return fmt.Errorf("failed to marshal session: %w", err)
 	}
-
-	// Marshal session parameters to JSON
-	paramsJSON, err := json.Marshal(&ssm.StartSessionInput{
-		Target: aws.String(targetName),
-	})
+	paramsJSON, err := json.Marshal(input)
 	if err != nil {
 		return fmt.Errorf("failed to marshal session parameters: %w", err)
 	}
 
-	// Execute the session
-	return internal.CallProcess(
+	if err := internal.CallProcess(
 		credential.ssmPluginPath,
 		string(sessionJSON),
 		credential.awsConfig.Region,
 		"StartSession",
 		credential.awsProfile,
 		string(paramsJSON),
-	)
+	); err != nil {
+		color.Red("%v", err)
+	}
+
+	return terminateSession(ctx, session.SessionId)
 }
 
 // terminateSession terminates the SSM session

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/fatih/color"
 	"github.com/kballard/go-shellquote"
@@ -63,7 +62,7 @@ func runSSHCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// Execute the SSH command
-	if err := executeSSHCommand(sshArgs, session, targetName); err != nil {
+	if err := runProxiedCommand("ssh", sshArgs, session, sshSessionInput(targetName)); err != nil {
 		color.Red("%v", err)
 	}
 
@@ -184,28 +183,19 @@ func resolveTargetHost(ctx context.Context, host string) (string, error) {
 	return instanceID, nil
 }
 
-// executeSSHCommand executes the SSH command with SSM as proxy
-func executeSSHCommand(sshArgs string, session *ssm.StartSessionOutput, targetName string) error {
-	// Marshal session information to JSON
+// runProxiedCommand executes ssh or scp with an SSM ProxyCommand option
+// followed by the user-supplied arguments. It is shared by ssh and scp.
+func runProxiedCommand(process, userArgs string, session *ssm.StartSessionOutput, input *ssm.StartSessionInput) error {
+	// Marshal session and parameters to JSON for the SSM plugin
 	sessionJSON, err := json.Marshal(session)
 	if err != nil {
 		return fmt.Errorf("failed to marshal session data: %w", err)
 	}
-
-	// Create parameter input for the SSM plugin
-	input := &ssm.StartSessionInput{
-		DocumentName: aws.String(documentNameSSH),
-		Parameters:   map[string][]string{"portNumber": {defaultSSHPort}},
-		Target:       aws.String(targetName),
-	}
-
-	// Marshal parameters to JSON
 	paramsJSON, err := json.Marshal(input)
 	if err != nil {
 		return fmt.Errorf("failed to marshal session parameters: %w", err)
 	}
 
-	// Build proxy command for SSH
 	proxyCommand := fmt.Sprintf("ProxyCommand=%s '%s' %s %s %s '%s'",
 		credential.ssmPluginPath,
 		string(sessionJSON),
@@ -215,15 +205,13 @@ func executeSSHCommand(sshArgs string, session *ssm.StartSessionOutput, targetNa
 		string(paramsJSON),
 	)
 
-	// Build SSH command arguments, respecting quoted segments
-	parsedArgs, err := shellquote.Split(sshArgs)
+	// Build the command arguments, respecting quoted segments
+	parsedArgs, err := shellquote.Split(userArgs)
 	if err != nil {
-		return fmt.Errorf("invalid SSH arguments: %w", err)
+		return fmt.Errorf("invalid %s arguments: %w", process, err)
 	}
-	cmdArgs := append([]string{"-o", proxyCommand}, parsedArgs...)
 
-	// Execute SSH command
-	return internal.CallProcess("ssh", cmdArgs...)
+	return internal.CallProcess(process, append([]string{"-o", proxyCommand}, parsedArgs...)...)
 }
 
 func init() {


### PR DESCRIPTION
Closes #31.

The dupl-flagged copies are gone, each replaced by one shared helper:

- **`runPluginSession`** (session.go): create session → marshal session+params → drive the session-manager-plugin → terminate. Shared by `start`, `fwd`, and `fwdrem`, whose per-command functions are now thin input builders.
- **`runProxiedCommand` + `sshSessionInput`** (ssh.go/scp.go): the verbatim-duplicated ProxyCommand construction and quoted-arg building, shared by `ssh` and `scp`.
- `findTargetInstances` (cmd.go) wraps the existing `findSpecificInstance` instead of carrying its own copy — the audit's three copies of "find instance by ID" are down to one.
- `setupAWSCredentials` now uses its `awsProfile` parameter (the `unparam` finding).

**Net −166 lines**, no behavior change; lint (including dupl in the audit config) and race tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)