### PR TITLE
fix: plugin download URLs broken by AWS layout change

### DIFF
--- a/internal/plugin_download.go
+++ b/internal/plugin_download.go
@@ -170,14 +170,20 @@ func getDownloadInfoForPlatform(version string) (string, func(string, string) (s
 				version, awsArch)
 			return url, extractFromRpm, nil
 		default:
-			// For other Linux distributions, use the direct binary
-			url := fmt.Sprintf("https://s3.amazonaws.com/session-manager-downloads/plugin/%s/linux_%s/session-manager-plugin",
+			// AWS stopped publishing raw Linux binaries; the .deb is the
+			// most extractable fallback (requires binutils' ar)
+			url := fmt.Sprintf("https://s3.amazonaws.com/session-manager-downloads/plugin/%s/ubuntu_%s/session-manager-plugin.deb",
 				version, awsArch)
-			return url, extractBinary, nil
+			return url, extractFromDeb, nil
 		}
 	case "darwin":
-		url := fmt.Sprintf("https://s3.amazonaws.com/session-manager-downloads/plugin/%s/mac_%s/session-manager-plugin.pkg",
-			version, awsArch)
+		// Intel packages live under mac/, Apple Silicon under mac_arm64/
+		macDir := "mac"
+		if goarch == "arm64" {
+			macDir = "mac_arm64"
+		}
+		url := fmt.Sprintf("https://s3.amazonaws.com/session-manager-downloads/plugin/%s/%s/session-manager-plugin.pkg",
+			version, macDir)
 		return url, extractFromPkg, nil
 	case "windows":
 		// Windows uses a different URL pattern - no architecture in path

--- a/internal/plugin_extract.go
+++ b/internal/plugin_extract.go
@@ -14,23 +14,6 @@ import (
 	"strings"
 )
 
-// extractBinary handles direct binary downloads (no packaging)
-func extractBinary(srcPath, destDir string) (string, error) {
-	destPath := filepath.Join(destDir, GetSsmPluginName())
-
-	// Copy the file
-	input, err := os.ReadFile(srcPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read binary: %w", err)
-	}
-
-	if err := os.WriteFile(destPath, input, 0755); err != nil {
-		return "", fmt.Errorf("failed to write binary: %w", err)
-	}
-
-	return destPath, nil
-}
-
 // extractFromDeb extracts the plugin binary from a .deb package
 func extractFromDeb(debPath, destDir string) (string, error) {
 	// Create a temporary directory to extract files

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -99,30 +99,6 @@ func TestValidatePlugin(t *testing.T) {
 	}
 }
 
-func TestExtractBinary(t *testing.T) {
-	src := filepath.Join(t.TempDir(), "downloaded")
-	content := []byte("binary-bytes")
-	if err := os.WriteFile(src, content, 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	destDir := t.TempDir()
-	destPath, err := extractBinary(src, destDir)
-	if err != nil {
-		t.Fatalf("extractBinary: %v", err)
-	}
-	if filepath.Base(destPath) != GetSsmPluginName() {
-		t.Errorf("dest name = %q", filepath.Base(destPath))
-	}
-	got, err := os.ReadFile(destPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, content) {
-		t.Errorf("extracted content = %q, want %q", got, content)
-	}
-}
-
 // buildZip writes a zip archive with the given name→content entries.
 func buildZip(t *testing.T, path string, entries map[string][]byte) {
 	t.Helper()


### PR DESCRIPTION
Found while building the #42 update automation: probing AWS's plugin bucket for the current version (1.2.835.0) shows the layout changed since this code was written.

| URL pattern | status |
|---|---|
| `linux_64bit/session-manager-plugin` (raw binary) | **403 — gone** |
| `mac_64bit/session-manager-plugin.pkg` | **403 — gone** |
| `mac/session-manager-plugin.pkg` | 200 (Intel moved here) |
| `mac_arm64/session-manager-plugin.pkg` | 200 |
| `ubuntu_*/…deb`, `linux_*/…rpm`, `windows/…zip` | 200 |

So runtime plugin downloads are broken today on **macOS Intel** (wrong directory) and **non-deb/non-rpm Linux** (raw binaries no longer exist). Users on those platforms silently fall back to the five-year-old embedded plugin.

## Fix

- darwin: `mac/` for amd64, `mac_arm64/` for arm64
- linux default branch: download the `.deb` (extracted with binutils' `ar`, widely available) instead of the vanished raw binary
- `extractBinary` deleted with its only caller (keeps `deadcode` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)