### PR TITLE
fix: normal session exit no longer reports a termination error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.322.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.73.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
+	github.com/aws/smithy-go v1.27.9
 	github.com/fatih/color v1.19.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/spf13/cobra v1.10.2
@@ -29,7 +30,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.7 // indirect
-	github.com/aws/smithy-go v1.27.9 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/ssm.go
+++ b/internal/ssm.go
@@ -20,6 +20,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
 	"github.com/fatih/color"
 )
 
@@ -71,6 +72,7 @@ type ec2API interface {
 type ssmAPI interface {
 	DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error)
 	GetCommandInvocation(ctx context.Context, params *ssm.GetCommandInvocationInput, optFns ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error)
+	TerminateSession(ctx context.Context, params *ssm.TerminateSessionInput, optFns ...func(*ssm.Options)) (*ssm.TerminateSessionOutput, error)
 }
 
 // AskUser prompts the user to select an SSH username
@@ -409,14 +411,25 @@ func CreateStartSession(ctx context.Context, cfg aws.Config, input *ssm.StartSes
 
 // DeleteStartSession terminates an SSM session
 func DeleteStartSession(ctx context.Context, cfg aws.Config, input *ssm.TerminateSessionInput) error {
-	client := ssm.NewFromConfig(cfg)
+	return deleteStartSession(ctx, ssm.NewFromConfig(cfg), input)
+}
 
+func deleteStartSession(ctx context.Context, client ssmAPI, input *ssm.TerminateSessionInput) error {
 	fmt.Printf("%s %s\n",
 		color.YellowString("Delete Session"),
 		color.YellowString(aws.ToString(input.SessionId)))
 
-	_, err := client.TerminateSession(ctx, input)
-	if err != nil {
+	if _, err := client.TerminateSession(ctx, input); err != nil {
+		// A session that ended on its own (the plugin exiting normally) is
+		// already terminated server-side, and the API rejects terminating
+		// it again — that is success, not an error.
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) {
+			switch apiErr.ErrorCode() {
+			case "ValidationException", "DoesNotExistException":
+				return nil
+			}
+		}
 		return fmt.Errorf("failed to terminate session: %w", err)
 	}
 

--- a/internal/ssm_test.go
+++ b/internal/ssm_test.go
@@ -13,6 +13,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
 )
 
 // fakeEC2 implements ec2API with configurable responses.
@@ -33,6 +34,7 @@ func (f *fakeEC2) DescribeRegions(_ context.Context, in *ec2.DescribeRegionsInpu
 type fakeSSM struct {
 	describeInstanceInformation func(*ssm.DescribeInstanceInformationInput) (*ssm.DescribeInstanceInformationOutput, error)
 	getCommandInvocation        func(*ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error)
+	terminateSession            func(*ssm.TerminateSessionInput) (*ssm.TerminateSessionOutput, error)
 }
 
 func (f *fakeSSM) DescribeInstanceInformation(_ context.Context, in *ssm.DescribeInstanceInformationInput, _ ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error) {
@@ -41,6 +43,10 @@ func (f *fakeSSM) DescribeInstanceInformation(_ context.Context, in *ssm.Describ
 
 func (f *fakeSSM) GetCommandInvocation(_ context.Context, in *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
 	return f.getCommandInvocation(in)
+}
+
+func (f *fakeSSM) TerminateSession(_ context.Context, in *ssm.TerminateSessionInput, _ ...func(*ssm.Options)) (*ssm.TerminateSessionOutput, error) {
+	return f.terminateSession(in)
 }
 
 func instanceInfo(ids ...string) []ssmtypes.InstanceInformation {
@@ -296,6 +302,36 @@ func TestMonitorCommandInvocation(t *testing.T) {
 
 		monitorCommandInvocation(context.Background(), f, &ssm.GetCommandInvocationInput{})
 	})
+}
+
+// Regression test for #48: a session that ended on its own is already
+// terminated server-side; cleanup must treat the API's rejection as success
+// instead of failing every normal Ctrl+D exit.
+func TestDeleteStartSessionAlreadyTerminated(t *testing.T) {
+	input := &ssm.TerminateSessionInput{SessionId: aws.String("s-1")}
+
+	for _, code := range []string{"ValidationException", "DoesNotExistException"} {
+		f := &fakeSSM{terminateSession: func(*ssm.TerminateSessionInput) (*ssm.TerminateSessionOutput, error) {
+			return nil, &smithy.GenericAPIError{Code: code, Message: "Session is not in a valid state"}
+		}}
+		if err := deleteStartSession(context.Background(), f, input); err != nil {
+			t.Errorf("%s should be treated as already terminated, got: %v", code, err)
+		}
+	}
+
+	denied := &fakeSSM{terminateSession: func(*ssm.TerminateSessionInput) (*ssm.TerminateSessionOutput, error) {
+		return nil, &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "nope"}
+	}}
+	if err := deleteStartSession(context.Background(), denied, input); err == nil {
+		t.Error("real API errors must still surface")
+	}
+
+	ok := &fakeSSM{terminateSession: func(*ssm.TerminateSessionInput) (*ssm.TerminateSessionOutput, error) {
+		return &ssm.TerminateSessionOutput{}, nil
+	}}
+	if err := deleteStartSession(context.Background(), ok, input); err != nil {
+		t.Errorf("unexpected error on clean termination: %v", err)
+	}
 }
 
 func TestGenerateSSHExecCommand(t *testing.T) {


### PR DESCRIPTION
Closes #48.

Ending a session normally (Ctrl+D) makes the session-manager-plugin terminate the SSM session itself, so gossm's unconditional `TerminateSession` cleanup hit `ValidationException: Session is not in a valid state` — printing an error and exiting 1 on **every clean session exit** (also breaking scripts that check the exit code).

`DeleteStartSession` now matches the error via `smithy.APIError`: `ValidationException` and `DoesNotExistException` mean the session is already gone and count as success; anything else (network, access denied) still surfaces. `TerminateSession` joined the mockable `ssmAPI` interface, with a regression test covering both ignorable codes, a real error, and the clean path.

Affects all session commands (`start`, `ssh`, `scp`, `fwd`, `fwdrem`) — they share this cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)